### PR TITLE
Fixed codecs for integers and doubles with tests

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -26,12 +26,16 @@ flag dev
   description: Use development GHC flags
 
 library
-  exposed-modules:     Data.Avro.Schema,
-                       Data.Avro.Types,
-                       Data.Avro.Decode,
-                       Data.Avro.Encode,
-                       Data.Avro.Deconflict,
-                       Data.Avro
+  exposed-modules:      Data.Avro,
+                        Data.Avro.Decode,
+                        Data.Avro.DecodeRaw,
+                        Data.Avro.Deconflict,
+                        Data.Avro.Encode,
+                        Data.Avro.EncodeRaw,
+                        Data.Avro.Schema,
+                        Data.Avro.Types,
+                        Data.Avro.Zag,
+                        Data.Avro.Zig
   -- other-modules:
   other-extensions:    OverloadedStrings
   build-depends:       base >=4.8 && <5.0,
@@ -41,6 +45,7 @@ library
                        binary,
                        bytestring,
                        containers,
+                       data-binary-ieee754,
                        entropy,
                        fail,
                        hashable,
@@ -59,31 +64,41 @@ library
     ghc-options: -Wall -Werror
 
 test-suite test
-  type:                exitcode-stdio-1.0
-  default-language:    Haskell2010
-  hs-source-dirs:      test
-  other-modules:       Avro.ToAvroSpec
-  main-is:             Spec.hs
-  ghc-options:         -threaded
+  type:                 exitcode-stdio-1.0
+  default-language:     Haskell2010
+  hs-source-dirs:       test
+  other-modules:        Avro.Codec.CodecRawSpec
+                      , Avro.Codec.DoubleSpec
+                      , Avro.Codec.Int64Spec
+                      , Avro.Codec.MaybeSpec
+                      , Avro.Codec.TextSpec
+                      , Avro.Codec.ZigZagSpec
+                      , Avro.EncodeRawSpec
+                      , Avro.ToAvroSpec
+
+  main-is:              Spec.hs
+  ghc-options:          -threaded
   if flag(dev)
     ghc-options: -Wall -Werror
-  build-depends:       base >=4.6 && < 5
-                     , avro
-                     , aeson
-                     , array
-                     , base16-bytestring
-                     , binary
-                     , bytestring
-                     , containers
-                     , entropy
-                     , fail
-                     , hashable
-                     , mtl
-                     , scientific
-                     , text
-                     , unordered-containers
-                     , vector
-                     , pure-zlib
-                     , semigroups
-                     , tagged
-                     , hspec
+  build-depends:        base >=4.6 && < 5
+                      , avro
+                      , aeson
+                      , array
+                      , base16-bytestring
+                      , binary
+                      , bytestring
+                      , containers
+                      , entropy
+                      , extra
+                      , fail
+                      , hashable
+                      , mtl
+                      , scientific
+                      , text
+                      , unordered-containers
+                      , vector
+                      , pure-zlib
+                      , semigroups
+                      , tagged
+                      , hspec
+                      , QuickCheck

--- a/src/Data/Avro/DecodeRaw.hs
+++ b/src/Data/Avro/DecodeRaw.hs
@@ -1,0 +1,65 @@
+module Data.Avro.DecodeRaw
+  ( DecodeRaw(..)
+  ) where
+
+import Data.Avro.Zag
+import Data.Binary.Get
+import Data.Bits
+import Data.Int
+import Data.List
+import Data.Word
+
+getNonNegative :: (Bits i, Integral i) => Get i
+getNonNegative = do
+  orig <- getWord8s
+  return (foldl' (\a x -> (a `shiftL` 7) + fromIntegral x) 0 (reverse orig))
+
+getWord8s :: Get [Word8]
+getWord8s = do
+  w <- getWord8
+  let msb = w `testBit` 7 in (w .&. 0x7F :) <$> if msb
+    then getWord8s
+    else return []
+
+class DecodeRaw a where
+  decodeRaw :: Get a
+
+instance DecodeRaw Word where
+  decodeRaw = getNonNegative
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Word8 where
+  decodeRaw = getNonNegative
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Word16 where
+  decodeRaw = getNonNegative
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Word32 where
+  decodeRaw = getNonNegative
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Word64 where
+  decodeRaw = getNonNegative
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Int where
+  decodeRaw = zag <$> (decodeRaw :: Get Word)
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Int8 where
+  decodeRaw = zag <$> (decodeRaw :: Get Word8)
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Int16 where
+  decodeRaw = zag <$> (decodeRaw :: Get Word16)
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Int32 where
+  decodeRaw = zag <$> (decodeRaw :: Get Word32)
+  {-# INLINE decodeRaw #-}
+
+instance DecodeRaw Int64 where
+  decodeRaw = zag <$> (decodeRaw :: Get Word64)
+  {-# INLINE decodeRaw #-}

--- a/src/Data/Avro/Encode.hs
+++ b/src/Data/Avro/Encode.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE TypeFamilies         #-}
+
 module Data.Avro.Encode
   ( -- * High level interface
     getSchema
@@ -10,6 +12,7 @@ module Data.Avro.Encode
   , encodeContainer, encodeContainerWithSync
   -- * Lower level interface
   , EncodeAvro(..)
+  , Zag(..)
   , putAvro
   ) where
 
@@ -19,6 +22,7 @@ import           Data.Array              (Array)
 import           Data.Ix                 (Ix)
 import           Data.Bits
 import           Data.ByteString.Lazy    as BL
+import qualified Data.Binary.IEEE754     as IEEE
 import           Data.ByteString.Lazy.Char8 ()
 import qualified Data.ByteString         as B
 import           Data.ByteString.Builder
@@ -26,10 +30,11 @@ import qualified Data.Foldable           as F
 import           Data.HashMap.Strict     (HashMap)
 import qualified Data.HashMap.Strict     as HashMap
 import           Data.Int
+import           Data.List               as DL
 import           Data.List.NonEmpty      (NonEmpty(..))
 import qualified Data.List.NonEmpty      as NE
 import           Data.Monoid
-import           Data.Maybe              (catMaybes)
+import           Data.Maybe              (catMaybes, mapMaybe)
 import           Data.Set                (Set)
 import           Data.Text               (Text)
 import qualified Data.Text               as T
@@ -42,8 +47,11 @@ import           Data.Word
 import           Data.Proxy
 import           System.Entropy (getEntropy)
 
+import Data.Avro.EncodeRaw
 import Data.Avro.Schema as S
 import Data.Avro.Types  as T
+import Data.Avro.Zag
+import Data.Avro.Zig
 
 encodeAvro :: EncodeAvro a => a -> BL.ByteString
 encodeAvro = toLazyByteString . putAvro
@@ -77,7 +85,6 @@ encodeContainerWithSync syncBytes xss =
   avroMagicBytes :: BL.ByteString
   avroMagicBytes = "Obj" <> BL.pack [1]
 
-
 -- XXX make an instance 'EncodeAvro Schema'
 -- Would require a schema schema...
 -- encodeSchema :: EncodeAvro a => a -> BL.ByteString
@@ -103,28 +110,15 @@ class EncodeAvro a where
 -- class PutAvro a where
 --   putAvro :: a -> Builder
 
-avroInt :: forall a. (FiniteBits a, Integral a) => a -> AvroM
-avroInt n = AvroM (putIntegral n, S.Int)
+avroInt :: forall a. (FiniteBits a, Integral a, EncodeRaw a) => a -> AvroM
+avroInt n = AvroM (encodeRaw n, S.Int)
 
-avroLong :: forall a. (FiniteBits a, Integral a) => a -> AvroM
-avroLong n = AvroM (putIntegral n, S.Long)
+avroLong :: forall a. (FiniteBits a, Integral a, EncodeRaw a) => a -> AvroM
+avroLong n = AvroM (encodeRaw n, S.Long)
 
 -- Put a Haskell Int.
 putI :: Int -> Builder
-putI = putIntegral
-
-putIntegral :: forall a. (FiniteBits a, Integral a) => a -> Builder
-putIntegral n =
-  let enc = (n `shiftL` 1) `xor` (n `shiftR` (finiteBitSize n - 1))
-  in if enc == 0 then word8 0
-                 else varEncode enc
- where
- varEncode :: a -> Builder
- varEncode 0 = mempty
- varEncode e =
-  word8 (gt e (e .&. 0x7f)) <> varEncode (e `shiftR` 7)
- gt x | x >= 0x80 = (`setBit` 7) . fromIntegral
-      | otherwise = fromIntegral
+putI = encodeRaw
 
 instance EncodeAvro Int  where
   avro = avroInt
@@ -147,63 +141,47 @@ instance EncodeAvro Word64 where
 instance EncodeAvro Text where
   avro t =
     let bs = T.encodeUtf8 t
-    in AvroM (putIntegral (B.length bs) <> byteString bs, S.String)
+    in AvroM (encodeRaw (B.length bs) <> byteString bs, S.String)
 instance EncodeAvro TL.Text where
   avro t =
     let bs = TL.encodeUtf8 t
-    in AvroM (putIntegral (BL.length bs) <> lazyByteString bs, S.String)
+    in AvroM (encodeRaw (BL.length bs) <> lazyByteString bs, S.String)
 
 instance EncodeAvro ByteString where
-  avro bs = AvroM (putIntegral (BL.length bs) <> lazyByteString bs, S.Bytes)
+  avro bs = AvroM (encodeRaw (BL.length bs) <> lazyByteString bs, S.Bytes)
 
 instance EncodeAvro B.ByteString where
-  avro bs = AvroM (putIntegral (B.length bs) <> byteString bs, S.Bytes)
+  avro bs = AvroM (encodeRaw (B.length bs) <> byteString bs, S.Bytes)
 
 instance EncodeAvro String where
   avro s = let t = T.pack s in avro t
 
 instance EncodeAvro Double where
-  avro d = AvroM (putIntegral longVal, S.Double)
-   where longVal :: Word64
-         longVal | isNaN d               = 0x7ff8000000000000
-                 | isInfinite d && d > 0 = 0x7ff0000000000000
-                 | isInfinite d          = 0xfff0000000000000
-                 | otherwise = (s `shiftL` 63) .|. (e `shiftL` 52) .|. g
-         s = fromIntegral (fromEnum (signum d < 0))
-         e = fromIntegral (exponent d)
-         g = floor (0x000fffffffffffff * significand d)
+  avro d = AvroM (word64LE (IEEE.doubleToWord d), S.Double)
 
 instance EncodeAvro Float where
-  avro d = AvroM (putIntegral intVal, S.Float)
-   where intVal :: Word32
-         intVal | isNaN d               = 0x7fc00000
-                | isInfinite d && d > 0 = 0x7f800000
-                | isInfinite d          = 0xff800000
-                | otherwise             = (s `shiftL` 31) .|. (e `shiftL` 23) .|. g
-         s = fromIntegral (fromEnum (signum d < 0))
-         e = fromIntegral (exponent d)
-         g = floor (0x007fffff * significand d)
+  avro d = AvroM (word32LE (IEEE.floatToWord d), S.Float)
 
 instance EncodeAvro a => EncodeAvro [a] where
-  avro xs = AvroM ( putIntegral (F.length xs) <> foldMap putAvro xs
+  avro xs = AvroM ( encodeRaw (F.length xs) <> foldMap putAvro xs
                   , S.Array (getType (Proxy :: Proxy a))
                   )
 
 instance (Ix i, EncodeAvro a) => EncodeAvro (Array i a) where
-  avro a = AvroM ( putIntegral (F.length a) <> foldMap putAvro a
+  avro a = AvroM ( encodeRaw (F.length a) <> foldMap putAvro a
                  , S.Array (getType (Proxy :: Proxy a))
                  )
 instance EncodeAvro a => EncodeAvro (Vector a) where
-  avro a = AvroM ( putIntegral (F.length a) <> foldMap putAvro a
+  avro a = AvroM ( encodeRaw (F.length a) <> foldMap putAvro a
                  , S.Array (getType (Proxy :: Proxy a))
                  )
 instance (U.Unbox a, EncodeAvro a) => EncodeAvro (U.Vector a) where
-  avro a = AvroM ( putIntegral (U.length a) <> foldMap putAvro (U.toList a)
+  avro a = AvroM ( encodeRaw (U.length a) <> foldMap putAvro (U.toList a)
                  , S.Array (getType (Proxy :: Proxy a))
                  )
 
 instance EncodeAvro a => EncodeAvro (Set a) where
-  avro a = AvroM ( putIntegral (F.length a) <> foldMap putAvro a
+  avro a = AvroM ( encodeRaw (F.length a) <> foldMap putAvro a
                  , S.Array (getType (Proxy :: Proxy a))
                  )
 
@@ -244,12 +222,12 @@ instance EncodeAvro (T.Value Type) where
       T.Array vec -> avro vec
       T.Map hm    -> avro hm
       T.Record ty hm ->
-        let bs = foldMap putAvro (catMaybes $ P.map (\f -> HashMap.lookup f hm) fs)
+        let bs = foldMap putAvro (mapMaybe (`HashMap.lookup` hm) fs)
             fs = P.map fldName (fields ty)
         in AvroM (bs, ty)
       T.Union opts sel val | F.length opts > 0 ->
-        case lookup sel (P.zip (NE.toList opts) [0..]) of
+        case DL.elemIndex sel (NE.toList opts) of
           Just idx -> AvroM (putI idx <> putAvro val, S.mkUnion opts)
           Nothing  -> error "Union encoding specifies type not found in schema"
       T.Fixed bs  -> avro bs
-      T.Enum sch@(S.Enum{..}) ix t -> AvroM (putI ix, sch)
+      T.Enum sch@S.Enum{..} ix t -> AvroM (putI ix, sch)

--- a/src/Data/Avro/EncodeRaw.hs
+++ b/src/Data/Avro/EncodeRaw.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE ScopedTypeVariables  #-}
+
+module Data.Avro.EncodeRaw
+  ( EncodeRaw(..)
+  ) where
+
+import Data.Avro.Zig
+import Data.Bits
+import Data.ByteString.Builder
+import Data.Int
+import Data.Monoid
+import Data.Word
+
+putNonNegative :: forall a. (FiniteBits a, Integral a) => a -> Builder
+putNonNegative n = if n .&. complement 0x7F == 0
+  then word8 $ fromIntegral (n .&. 0x7f)
+  else word8 (0x80 .|. (fromIntegral n .&. 0x7F)) <> putNonNegative (n `shiftR` 7)
+
+class EncodeRaw a where
+  encodeRaw :: a -> Builder
+
+instance EncodeRaw Word where
+  encodeRaw = putNonNegative
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Word8 where
+  encodeRaw = putNonNegative
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Word16 where
+  encodeRaw = putNonNegative
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Word32 where
+  encodeRaw = putNonNegative
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Word64 where
+  encodeRaw = putNonNegative
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Int where
+  encodeRaw = encodeRaw . zig
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Int8 where
+  encodeRaw = encodeRaw . zig
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Int16 where
+  encodeRaw = encodeRaw . zig
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Int32 where
+  encodeRaw = encodeRaw . zig
+  {-# INLINE encodeRaw #-}
+
+instance EncodeRaw Int64 where
+  encodeRaw = encodeRaw . zig
+  {-# INLINE encodeRaw #-}

--- a/src/Data/Avro/Zag.hs
+++ b/src/Data/Avro/Zag.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TypeFamilies         #-}
+
+module Data.Avro.Zag
+  ( Zag(..)
+  ) where
+
+import Data.Bits
+import Data.Int
+import Data.Word
+
+class Zag a where
+  type Zagged a
+  zag :: a -> Zagged a
+
+instance Zag Word8 where
+  type Zagged Word8 = Int8
+  zag n = fromIntegral $ (n `shiftR` 1) `xor` negate (n .&. 0x1)
+  {-# INLINE zag #-}
+
+instance Zag Word16 where
+  type Zagged Word16 = Int16
+  zag n = fromIntegral $ (n `shiftR` 1) `xor` negate (n .&. 0x1)
+  {-# INLINE zag #-}
+
+instance Zag Word32 where
+  type Zagged Word32 = Int32
+  zag n = fromIntegral $ (n `shiftR` 1) `xor` negate (n .&. 0x1)
+  {-# INLINE zag #-}
+
+instance Zag Word64 where
+  type Zagged Word64 = Int64
+  zag n = fromIntegral $ (n `shiftR` 1) `xor` negate (n .&. 0x1)
+  {-# INLINE zag #-}
+
+instance Zag Word where
+  type Zagged Word = Int
+  zag n = fromIntegral $ (n `shiftR` 1) `xor` negate (n .&. 0x1)
+  {-# INLINE zag #-}

--- a/src/Data/Avro/Zig.hs
+++ b/src/Data/Avro/Zig.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TypeFamilies         #-}
+
+module Data.Avro.Zig
+  ( Zig(..)
+  ) where
+
+import Data.Bits
+import Data.Int
+import Data.Word
+
+class Zig a where
+  type Zigged a
+  zig :: a -> Zigged a
+
+instance Zig Int8 where
+  type Zigged Int8 = Word8
+  zig n = fromIntegral $ (n `shiftL` 1) `xor` (n `shiftR` (finiteBitSize n - 1))
+  {-# INLINE zig #-}
+
+instance Zig Int16 where
+  type Zigged Int16 = Word16
+  zig n = fromIntegral $ (n `shiftL` 1) `xor` (n `shiftR` (finiteBitSize n - 1))
+  {-# INLINE zig #-}
+
+instance Zig Int32 where
+  type Zigged Int32 = Word32
+  zig n = fromIntegral $ (n `shiftL` 1) `xor` (n `shiftR` (finiteBitSize n - 1))
+  {-# INLINE zig #-}
+
+instance Zig Int64 where
+  type Zigged Int64 = Word64
+  zig n = fromIntegral $ (n `shiftL` 1) `xor` (n `shiftR` (finiteBitSize n - 1))
+  {-# INLINE zig #-}
+
+instance Zig Int where
+  type Zigged Int = Word
+  zig n = fromIntegral $ (n `shiftL` 1) `xor` (n `shiftR` (finiteBitSize n - 1))
+  {-# INLINE zig #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-7.13
+resolver: lts-8.3
 
 # Local packages, usually specified by relative directory name.
 packages:

--- a/test/Avro/Codec/BoolSpec.hs
+++ b/test/Avro/Codec/BoolSpec.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Avro.Codec.BoolSpec (spec) where
+
+import Test.Hspec
+import qualified Test.QuickCheck as Q
+
+import           Data.List.NonEmpty (NonEmpty(..))
+import           Data.Tagged
+import           Data.Text
+import qualified Data.ByteString.Lazy as BL
+
+import           Data.Avro
+import           Data.Avro.Schema
+import qualified Data.Avro.Types as AT
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+-- Avro definition for Bool
+
+newtype OnlyBool = OnlyBool
+  { onlyBoolValue :: Bool
+  } deriving (Show, Eq)
+
+onlyBoolSchema :: Schema
+onlyBoolSchema =
+  let fld nm = Field nm [] Nothing Nothing
+   in Record "OnlyBool" (Just "test.contract") [] Nothing Nothing
+        [ fld "onlyBoolValue" Boolean Nothing
+        ]
+
+instance ToAvro OnlyBool where
+  toAvro sa = record onlyBoolSchema
+    [ "onlyBoolValue" .= onlyBoolValue sa
+    ]
+  schema = pure onlyBoolSchema
+
+instance FromAvro OnlyBool where
+  fromAvro (AT.Record _ r) =
+    OnlyBool <$> r .: "onlyBoolValue"
+
+spec :: Spec
+spec = describe "Avro.Codec.BoolSpec" $ do
+  let x = untag (schema :: Tagged OnlyBool Type)
+  it "should encode True correctly" $ do
+    let trueEncoding = BL.singleton 0x01
+    encode (OnlyBool True) `shouldBe` trueEncoding
+
+  it "should encode False correctly" $ do
+    let falseEncoding = BL.singleton 0x00
+    encode (OnlyBool False) `shouldBe` falseEncoding
+
+  it "should encode then decode True correctly" $ do
+    decode x (encode $ OnlyBool True) `shouldBe` Success (OnlyBool True)
+
+  it "should encode then decode False correctly" $ do
+    decode x (encode $ OnlyBool False) `shouldBe` Success (OnlyBool False)

--- a/test/Avro/Codec/CodecRawSpec.hs
+++ b/test/Avro/Codec/CodecRawSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Avro.Codec.CodecRawSpec (spec) where
+
+import Data.Avro.DecodeRaw
+import Data.Avro.EncodeRaw
+import Data.Binary.Get
+import Data.ByteString.Builder
+import Data.Int
+import Data.Word
+import Test.Hspec
+import qualified Test.QuickCheck as Q
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+spec :: Spec
+spec = describe "Avro.Codec.CodecRawSpec" $ do
+  it "codec raw round trip Int"     $ Q.property $ \(w :: Int)    -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Int8"    $ Q.property $ \(w :: Int8)   -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Int16"   $ Q.property $ \(w :: Int16)  -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Int32"   $ Q.property $ \(w :: Int32)  -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Int64"   $ Q.property $ \(w :: Int64)  -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Word"    $ Q.property $ \(w :: Word)   -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Word8"   $ Q.property $ \(w :: Word8)  -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Word16"  $ Q.property $ \(w :: Word16) -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Word32"  $ Q.property $ \(w :: Word32) -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w
+  it "codec raw round trip Word64"  $ Q.property $ \(w :: Word64) -> runGet decodeRaw (toLazyByteString (encodeRaw w)) == w

--- a/test/Avro/Codec/DoubleSpec.hs
+++ b/test/Avro/Codec/DoubleSpec.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Avro.Codec.DoubleSpec (spec) where
+
+import           Data.Avro
+import           Data.Avro.Schema
+import           Data.Tagged
+import           Test.Hspec
+import qualified Data.Avro.Types      as AT
+import qualified Data.ByteString.Lazy as BL
+import qualified Test.QuickCheck      as Q
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+newtype OnlyDouble = OnlyDouble
+  {onlyDoubleValue :: Double
+  } deriving (Show, Eq)
+
+onlyDoubleSchema :: Schema
+onlyDoubleSchema =
+  let fld nm = Field nm [] Nothing Nothing
+  in Record "OnlyDouble" (Just "test.contract") [] Nothing Nothing
+        [ fld "onlyDoubleValue" Double Nothing
+        ]
+
+instance ToAvro OnlyDouble where
+  toAvro sa = record onlyDoubleSchema
+    [ "onlyDoubleValue" .= onlyDoubleValue sa ]
+  schema = pure onlyDoubleSchema
+
+instance FromAvro OnlyDouble where
+  fromAvro (AT.Record _ r) =
+    OnlyDouble <$> r .: "onlyDoubleValue"
+
+spec :: Spec
+spec = describe "Avro.Codec.DoubleSpec" $ do
+  it "Can decode 0.89" $ do
+    let expectedBuffer = BL.pack [123, 20, -82, 71, -31, 122, -20, 63]
+    let value = OnlyDouble 0.89
+    encode value `shouldBe` expectedBuffer
+
+  it "Can decode -2.0" $ do
+    let expectedBuffer = BL.pack [0, 0, 0, 0, 0, 0, 0, -64]
+    let value = OnlyDouble (-2.0)
+    encode value `shouldBe` expectedBuffer
+
+  it "Can decode 1.0" $ do
+    let expectedBuffer = [0, 0, 0, 0, 0, 0, -16, 63]
+    let value = OnlyDouble 1.0
+    BL.unpack (encode value) `shouldBe` expectedBuffer
+
+  it "Can decode encoded Double values" $ do
+    Q.property $ \(d :: Double) ->
+      let x = untag (schema :: Tagged OnlyDouble Type) in
+        decode x (encode (OnlyDouble d)) == Success (OnlyDouble d)

--- a/test/Avro/Codec/Int64Spec.hs
+++ b/test/Avro/Codec/Int64Spec.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Avro.Codec.Int64Spec (spec) where
+
+import           Data.Avro
+import           Data.Avro.Encode
+import           Data.Avro.Schema
+import           Data.Avro.Zig
+import           Data.Bits
+import           Data.ByteString.Builder
+import           Data.Int
+import           Data.List.Extra
+import           Data.Tagged
+import           Data.Word
+import           Numeric (showHex)
+import           Test.Hspec
+import qualified Data.Avro.Types      as AT
+import qualified Data.ByteString.Lazy as BL
+import qualified Test.QuickCheck      as Q
+import Debug.Trace
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+
+prettyPrint :: BL.ByteString -> String
+prettyPrint = concatMap (`showHex` "") . BL.unpack
+
+newtype OnlyInt64 = OnlyInt64
+  { onlyInt64Value :: Int64
+  } deriving (Show, Eq)
+
+onlyInt64Schema :: Schema
+onlyInt64Schema =
+  let fld nm = Field nm [] Nothing Nothing
+   in Record "OnlyInt64" (Just "test.contract") [] Nothing Nothing
+        [ fld "onlyInt64Value"    Long Nothing
+        ]
+
+instance ToAvro OnlyInt64 where
+  toAvro sa = record onlyInt64Schema
+    [ "onlyInt64Value" .= onlyInt64Value sa
+    ]
+  schema = pure onlyInt64Schema
+
+instance FromAvro OnlyInt64 where
+  fromAvro (AT.Record _ r) =
+    OnlyInt64  <$> r .: "onlyInt64Value"
+
+bitStringToWord8s :: String -> [Word8]
+bitStringToWord8s = reverse . map (toWord . reverse) . chunksOf 8 . reverse . toBinary
+  where toBinary :: String -> [Bool]
+        toBinary ('1':xs) = True  : toBinary xs
+        toBinary ('0':xs) = False : toBinary xs
+        toBinary (_  :xs) = toBinary xs
+        toBinary       [] = []
+        toWord' :: Word8 -> [Bool] -> Word8
+        toWord' n (True :bs)  = toWord' ((n `shiftL` 1) .|. 1) bs
+        toWord' n (False:bs)  = toWord' ((n `shiftL` 1) .|. 0) bs
+        toWord' n _           = n
+        toWord = toWord' 0
+
+spec :: Spec
+spec = describe "Avro.Codec.Int64Spec" $ do
+  it "Can encode 90071992547409917L correctly" $ do
+    let expectedBuffer = BL.pack [0xfa, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xbf, 0x02]
+    let value = OnlyInt64 90071992547409917
+    encode value `shouldBe` expectedBuffer
+  it "Can decode 90071992547409917L correctly" $ do
+    let x = untag (schema :: Tagged OnlyInt64 Type)
+    let buffer = BL.pack [0xfa, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xbf, 0x02]
+    let expectedValue = OnlyInt64 90071992547409917
+    decode x buffer `shouldBe` Success expectedValue
+  it "Can decode encoded Int64 values" $ do
+    let x = untag (schema :: Tagged OnlyInt64 Type)
+    Q.property $ \(w :: Int64) -> decode x (encode (OnlyInt64 w)) == Success (OnlyInt64 w)
+
+  it "Can decode 129L" $ do
+    let w = 129 :: Int64
+    let x = untag (schema :: Tagged OnlyInt64 Type)
+    decode x (encode (OnlyInt64 w)) == Success (OnlyInt64 w)
+
+  it "Can decode 36028797018963968 correctly" $ do
+    let x = untag (schema :: Tagged OnlyInt64 Type)
+    let buffer = BL.pack (bitStringToWord8s "10000000 10000000 10000000 10000000 10000000 10000000 10000000 10000000 00000001")
+    let expectedValue = OnlyInt64 36028797018963968
+    decode x buffer `shouldBe` Success expectedValue
+
+  it "bitStringToWord8s 00000000"                   $  bitStringToWord8s "00000000"                    `shouldBe` [0x00             ]
+  it "bitStringToWord8s 00000001"                   $  bitStringToWord8s "00000001"                    `shouldBe` [0x01             ]
+  it "bitStringToWord8s 01111111"                   $  bitStringToWord8s "01111111"                    `shouldBe` [0x7f             ]
+  it "bitStringToWord8s 10000000 00000001"          $  bitStringToWord8s "10000000 00000001"           `shouldBe` [0x80, 0x01       ]
+  it "bitStringToWord8s 10000001 00000001"          $  bitStringToWord8s "10000001 00000001"           `shouldBe` [0x81, 0x01       ]
+  it "bitStringToWord8s 10000010 00000001"          $  bitStringToWord8s "10000010 00000001"           `shouldBe` [0x82, 0x01       ]
+  it "bitStringToWord8s 11111111 01111111"          $  bitStringToWord8s "11111111 01111111"           `shouldBe` [0xff, 0x7f       ]
+  it "bitStringToWord8s 10000000 10000000 00000001" $  bitStringToWord8s "10000000 10000000 00000001"  `shouldBe` [0x80, 0x80, 0x01 ]
+  it "bitStringToWord8s 10000001 10000000 00000001" $  bitStringToWord8s "10000001 10000000 00000001"  `shouldBe` [0x81, 0x80, 0x01 ]
+  it "bitStringToWord8s 10000001 10000000 00000000" $  bitStringToWord8s "10000001 10000000 00000000"  `shouldBe` [0x81, 0x80, 0x00 ]
+
+  it "Can zig" $ do
+    zig (          0 :: Int64)  `shouldBe` 0
+    zig (         -1 :: Int64)  `shouldBe` 1
+    zig (          1 :: Int64)  `shouldBe` 2
+    zig (         -2 :: Int64)  `shouldBe` 3
+    zig ( 2147483647 :: Int64)  `shouldBe` 4294967294
+    zig (-2147483648 :: Int64)  `shouldBe` 4294967295

--- a/test/Avro/Codec/MaybeSpec.hs
+++ b/test/Avro/Codec/MaybeSpec.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Avro.Codec.MaybeSpec (spec) where
+
+import           Test.Hspec
+import qualified Test.QuickCheck as Q
+
+import           Data.List.NonEmpty (NonEmpty(..))
+import           Data.Tagged
+import           Data.Text
+
+import           Data.Avro
+import           Data.Avro.Schema
+import qualified Data.Avro.Types as AT
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+newtype OnlyMaybeBool = OnlyMaybeBool
+  { onlyMaybeBoolValue :: Maybe Bool
+  } deriving (Show, Eq)
+
+onlyMaybeBoolSchema :: Schema
+onlyMaybeBoolSchema =
+  let fld nm = Field nm [] Nothing Nothing
+   in Record "onlyMaybeBool" (Just "test.contract") [] Nothing Nothing
+        [ fld "onlyMaybeBoolValue" (mkUnion (Null :| [Boolean])) Nothing
+        ]
+
+instance ToAvro OnlyMaybeBool where
+  toAvro sa = record onlyMaybeBoolSchema
+    [ "onlyMaybeBoolValue" .= onlyMaybeBoolValue sa
+    ]
+  schema = pure onlyMaybeBoolSchema
+
+instance FromAvro OnlyMaybeBool where
+  fromAvro (AT.Record _ r) =
+    OnlyMaybeBool <$> r .: "onlyMaybeBoolValue"
+
+spec :: Spec
+spec = describe "Avro.Codec.MaybeSpec" $ do
+  it "should encode then decode Maybe Bool correctly" $ do
+    Q.property $ \(w :: Maybe Bool) ->
+      let x = untag (schema :: Tagged OnlyMaybeBool Type) in
+        decode x (encode (OnlyMaybeBool w)) `shouldBe` Success (OnlyMaybeBool w)

--- a/test/Avro/Codec/TextSpec.hs
+++ b/test/Avro/Codec/TextSpec.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Avro.Codec.TextSpec (spec) where
+
+import           Data.Avro
+import           Data.Avro.Schema
+import           Data.Text
+import           Data.Tagged
+import           Test.Hspec
+import qualified Data.Avro.Types      as AT
+import qualified Test.QuickCheck      as Q
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+newtype OnlyText = OnlyText
+  {onlyTextValue :: Text
+  } deriving (Show, Eq)
+
+onlyTextSchema :: Schema
+onlyTextSchema =
+  let fld nm = Field nm [] Nothing Nothing
+  in Record "OnlyText" (Just "test.contract") [] Nothing Nothing
+        [ fld "onlyTextValue" String Nothing
+        ]
+
+instance ToAvro OnlyText where
+  toAvro sa = record onlyTextSchema
+    [ "onlyTextValue" .= onlyTextValue sa ]
+  schema = pure onlyTextSchema
+
+instance FromAvro OnlyText where
+  fromAvro (AT.Record _ r) =
+    OnlyText <$> r .: "onlyTextValue"
+
+spec :: Spec
+spec = describe "Avro.Codec.TextSpec" $ do
+  it "Can decode \"This is an unit test\"" $ do
+    -- The '(' here is the length (ASCII value) of the string
+    let expectedBuffer = "(This is an unit test"
+    let value = OnlyText "This is an unit test"
+    encode value `shouldBe` expectedBuffer
+
+  it "Can decode encoded Text values" $ do
+    Q.property $ \(t :: String) ->
+      let x = untag (schema :: Tagged OnlyText Type) in
+        decode x (encode (OnlyText (pack t))) == Success (OnlyText (pack t))

--- a/test/Avro/Codec/ZigZagSpec.hs
+++ b/test/Avro/Codec/ZigZagSpec.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Avro.Codec.ZigZagSpec (spec) where
+
+import Data.Avro.Zag
+import Data.Avro.Zig
+import Data.Int
+import Data.Word
+import Test.Hspec
+import Test.QuickCheck
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+spec :: Spec
+spec = describe "Avro.Codec.Int64Spec" $ do
+  it "Zig and zag roundtrips for Int"     $ property $ \(w :: Int   ) -> zag (zig w) `shouldBe` w
+  it "Zig and zag roundtrips for Int8"    $ property $ \(w :: Int8  ) -> zag (zig w) `shouldBe` w
+  it "Zig and zag roundtrips for Int16"   $ property $ \(w :: Int16 ) -> zag (zig w) `shouldBe` w
+  it "Zig and zag roundtrips for Int32"   $ property $ \(w :: Int32 ) -> zag (zig w) `shouldBe` w
+  it "Zig and zag roundtrips for Int64"   $ property $ \(w :: Int64 ) -> zag (zig w) `shouldBe` w
+  it "Zag and zig roundtrips for Word"    $ property $ \(w :: Word  ) -> zig (zag w) `shouldBe` w
+  it "Zag and zig roundtrips for Word8"   $ property $ \(w :: Word8 ) -> zig (zag w) `shouldBe` w
+  it "Zag and zig roundtrips for Word16"  $ property $ \(w :: Word16) -> zig (zag w) `shouldBe` w
+  it "Zag and zig roundtrips for Word32"  $ property $ \(w :: Word32) -> zig (zag w) `shouldBe` w
+  it "Zag and zig roundtrips for Word64"  $ property $ \(w :: Word64) -> zig (zag w) `shouldBe` w

--- a/test/Avro/EncodeRawSpec.hs
+++ b/test/Avro/EncodeRawSpec.hs
@@ -1,0 +1,51 @@
+module Avro.EncodeRawSpec (spec) where
+
+import           Data.Avro.EncodeRaw
+import           Data.Bits
+import           Data.ByteString.Builder
+import           Data.List.Extra
+import           Data.Word
+import           Test.Hspec
+import qualified Data.ByteString.Lazy as BL
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+bitStringToWord8s :: String -> [Word8]
+bitStringToWord8s = reverse . map (toWord . reverse) . chunksOf 8 . reverse . toBinary
+  where toBinary :: String -> [Bool]
+        toBinary ('1':xs) = True  : toBinary xs
+        toBinary ('0':xs) = False : toBinary xs
+        toBinary (_  :xs) = toBinary xs
+        toBinary       [] = []
+        toWord' :: Word8 -> [Bool] -> Word8
+        toWord' n (True :bs)  = toWord' ((n `shiftL` 1) .|. 1) bs
+        toWord' n (False:bs)  = toWord' ((n `shiftL` 1) .|. 0) bs
+        toWord' n _           = n
+        toWord = toWord' 0
+
+spec :: Spec
+spec = describe "Avro.EncodeRawSpec" $ do
+  it "Can encodeRaw (                  0 :: Word64)" $ toLazyByteString (encodeRaw (                  0 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                                                 00000000" )
+  it "Can encodeRaw (                  1 :: Word64)" $ toLazyByteString (encodeRaw (                  1 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                                                 00000001" )
+  it "Can encodeRaw (                  2 :: Word64)" $ toLazyByteString (encodeRaw (                  2 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                                                 00000010" )
+  it "Can encodeRaw (                127 :: Word64)" $ toLazyByteString (encodeRaw (                127 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                                                 01111111" )
+  it "Can encodeRaw (                129 :: Word64)" $ toLazyByteString (encodeRaw (                129 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                                        10000001 00000001" )
+  it "Can encodeRaw (                130 :: Word64)" $ toLazyByteString (encodeRaw (                130 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                                        10000010 00000001" )
+  it "Can encodeRaw (              16383 :: Word64)" $ toLazyByteString (encodeRaw (              16383 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                                        11111111 01111111" )
+  it "Can encodeRaw (              16385 :: Word64)" $ toLazyByteString (encodeRaw (              16385 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                               10000001 10000000 00000001" )
+  it "Can encodeRaw (            2097153 :: Word64)" $ toLazyByteString (encodeRaw (            2097153 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                      10000001 10000000 10000000 00000001" )
+  it "Can encodeRaw (          268435457 :: Word64)" $ toLazyByteString (encodeRaw (          268435457 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                             10000001 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (        34359738369 :: Word64)" $ toLazyByteString (encodeRaw (        34359738369 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                    10000001 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (      4398046511105 :: Word64)" $ toLazyByteString (encodeRaw (      4398046511105 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                           10000001 10000000 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (    562949953421313 :: Word64)" $ toLazyByteString (encodeRaw (    562949953421313 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                  10000001 10000000 10000000 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (  72057594037927937 :: Word64)" $ toLazyByteString (encodeRaw (  72057594037927937 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "         10000001 10000000 10000000 10000000 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (9223372036854775809 :: Word64)" $ toLazyByteString (encodeRaw (9223372036854775809 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "10000001 10000000 10000000 10000000 10000000 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (                128 :: Word64)" $ toLazyByteString (encodeRaw (                128 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                                        10000000 00000001" )
+  it "Can encodeRaw (              16384 :: Word64)" $ toLazyByteString (encodeRaw (              16384 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                               10000000 10000000 00000001" )
+  it "Can encodeRaw (            2097153 :: Word64)" $ toLazyByteString (encodeRaw (            2097152 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                                      10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (          268435457 :: Word64)" $ toLazyByteString (encodeRaw (          268435456 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                             10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (        34359738369 :: Word64)" $ toLazyByteString (encodeRaw (        34359738368 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                                    10000000 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (      4398046511105 :: Word64)" $ toLazyByteString (encodeRaw (      4398046511104 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                           10000000 10000000 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (    562949953421313 :: Word64)" $ toLazyByteString (encodeRaw (    562949953421312 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "                  10000000 10000000 10000000 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (  72057594037927936 :: Word64)" $ toLazyByteString (encodeRaw (  72057594037927936 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "         10000000 10000000 10000000 10000000 10000000 10000000 10000000 10000000 00000001" )
+  it "Can encodeRaw (9223372036854775808 :: Word64)" $ toLazyByteString (encodeRaw (9223372036854775808 :: Word64)) `shouldBe` BL.pack (bitStringToWord8s "10000000 10000000 10000000 10000000 10000000 10000000 10000000 10000000 10000000 00000001" )

--- a/test/Avro/ToAvroSpec.hs
+++ b/test/Avro/ToAvroSpec.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Avro.ToAvroSpec
 where
 
@@ -8,8 +10,13 @@ import           Data.Text
 import           Data.Avro.Schema
 import qualified Data.Avro.Types as AT
 import           Data.List.NonEmpty (NonEmpty(..))
-
+import           Data.Tagged
+import           Data.Word
+import qualified Data.ByteString.Lazy as BL
 import Test.Hspec
+import qualified Test.QuickCheck as Q
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
 
 data TypesTestMessage = TypesTestMessage
   { tmId          :: Int64
@@ -65,5 +72,5 @@ message = TypesTestMessage
 
 spec :: Spec
 spec = describe "Kafka.IntegrationSpec" $ do
-    it "sends messages to test topic" $ do
-      fromAvro (toAvro message) `shouldBe` pure message
+  it "sends messages to test topic" $ do
+    fromAvro (toAvro message) `shouldBe` pure message


### PR DESCRIPTION
* Fixes the codecs for integers and doubles
* Use existing IEEE haskell library for floating point
* Modularise the code, by:
  - Introducing `EncodeRaw/DecodeRaw` type classes
  - Introducing `Zig/Zag` type classes that do zigzag encode/decode in a type-safe way.
* Unit and property tests for `Double`, `Int64`, `Maybe`, `Text`
