### PR TITLE
Use the passed-in value in getSchema.

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -121,6 +121,7 @@ test-suite test
     other-modules:    Avro.THEnumSpec
                     , Avro.THReusedSpec
                     , Avro.THSimpleSpec
+                    , Avro.THEncodeContainerSpec
 
   main-is:              Spec.hs
   ghc-options:          -threaded

--- a/src/Data/Avro/Encode.hs
+++ b/src/Data/Avro/Encode.hs
@@ -91,13 +91,13 @@ encodeContainerWithSync syncBytes xss =
 -- encodeSchema = toLazyByteString . putAvro . getSchema
 
 putAvro :: EncodeAvro a => a -> Builder
-putAvro   = fst . runAvro . avro
+putAvro = fst . runAvro . avro
 
 getSchema :: forall a. EncodeAvro a => a -> Schema
-getSchema _ = getType (Proxy :: Proxy a)
+getSchema = snd . runAvro . avro
 
 getType :: EncodeAvro a => Proxy a -> Type
-getType p = snd (runAvro (avro (undefined `asProxyTypeOf` p)))
+getType = getSchema . (asProxyTypeOf undefined)
 -- N.B. ^^^ Local knowledge that 'fst' won't be used,
 -- so the bottom of 'undefined' will not escape so long as schema creation
 -- remains lazy in the argument.

--- a/test/Avro/THEncodeContainerSpec.hs
+++ b/test/Avro/THEncodeContainerSpec.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Avro.THEncodeContainerSpec where
+
+import Data.Avro
+import Data.Avro.Deriving
+
+import Test.Hspec
+
+import Control.Monad (void)
+import Control.Exception
+
+deriveAvro "test/data/record.avsc"
+
+spec :: Spec
+spec = describe "Avro.EncodeContainerSpec" $
+  it "should encode data to a container of bytes" $
+    (encodeContainer [[Thing 1]] >>= void . evaluate) `shouldReturn` ()

--- a/test/data/record.avsc
+++ b/test/data/record.avsc
@@ -1,0 +1,8 @@
+{
+  "type" : "record",
+  "name" : "Thing",
+  "fields" : [ {
+    "name" : "value",
+    "type" : "int"
+  } ]
+}


### PR DESCRIPTION
Make it mirror putAvro.
Instead of calling the undefined-containing getType.

This fixes an issue I was having trying to write instance data to avro bytes, where it was hitting that undefined:
```
Prelude.undefined
CallStack (from HasCallStack):
  error, called at libraries/base/GHC/Err.hs:79:14 in base:GHC.Err
  undefined, called at src/Data/Avro/Encode.hs:100:33 in avro-0.2.0.0-7D9gyFVmhinCwIHovPxGOA:Data.Avro.Encode
```
When running the example at https://gist.github.com/LeifW/ce871f491d2e9a22162c3e1e7e3cd813
Which is a record of a single field. The code seemed to work fine if instead of a record I just used a single "primitive" type.