### PR TITLE
Routine fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Assuming there is a data type to be encoded/decoded from/to Avro:
 data Gender = Male | Female deriving (Eq, Ord, Show, Enum)
 data Person = Person
      { fullName :: Text
-     , age      :: Int
+     , age      :: Int32
      , gender   :: Gender
      , ssn      :: Maybe Text
      } deriving (Show, Eq)

--- a/avro.cabal
+++ b/avro.cabal
@@ -84,6 +84,7 @@ test-suite test
                       , Avro.Codec.BoolSpec
                       , Avro.Codec.CodecRawSpec
                       , Avro.Codec.DoubleSpec
+                      , Avro.Codec.FloatSpec
                       , Avro.Codec.Int64Spec
                       , Avro.Codec.MaybeSpec
                       , Avro.Codec.NestedSpec

--- a/avro.cabal
+++ b/avro.cabal
@@ -56,13 +56,13 @@ library
                        fail,
                        hashable,
                        mtl,
+                       pure-zlib,
                        scientific,
+                       semigroups,
+                       tagged,
                        text,
                        unordered-containers,
-                       vector,
-                       pure-zlib,
-                       semigroups,
-                       tagged
+                       vector
 
   if flag(templateHaskell)
     build-depends: template-haskell >= 2.4
@@ -94,9 +94,10 @@ test-suite test
                       , Avro.ToAvroSpec
 
   build-depends:        base >=4.6 && < 5
-                      , avro
                       , aeson
+                      , lens-aeson
                       , array
+                      , avro
                       , base16-bytestring
                       , binary
                       , bytestring
@@ -105,16 +106,18 @@ test-suite test
                       , extra
                       , fail
                       , hashable
+                      , hspec
+                      , lens
                       , mtl
-                      , scientific
-                      , text
-                      , unordered-containers
-                      , vector
                       , pure-zlib
+                      , QuickCheck
+                      , scientific
                       , semigroups
                       , tagged
-                      , hspec
-                      , QuickCheck
+                      , text
+                      , transformers
+                      , unordered-containers
+                      , vector
 
   if flag(templateHaskell)
     build-depends: template-haskell

--- a/avro.cabal
+++ b/avro.cabal
@@ -2,7 +2,7 @@
 -- see http://haskell.org/cabal/users-guide/
 
 name:                avro
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            Avro serialization support for Haskell
 description:         Avro serialization and deserialization support for Haskell
 homepage:            https://github.com/haskell-works/hw-haskell-avro.git

--- a/src/Data/Avro.hs
+++ b/src/Data/Avro.hs
@@ -74,7 +74,7 @@ module Data.Avro
   , HasAvroSchema(..)
   , Avro
   , (.:)
-  , (.=), record
+  , (.=), record, fixed
   , Result(..), badValue
   , decode
   , decodeWithSchema
@@ -178,7 +178,8 @@ decodeContainerBytes bs =
 record :: Foldable f => Type -> f (Text,T.Value Type) -> T.Value Type
 record ty = T.Record ty . HashMap.fromList . toList
 
-
+fixed :: Type -> B.ByteString -> T.Value Type
+fixed = T.Fixed
 -- @enumToAvro val@ will generate an Avro encoded value of enum suitable
 -- for serialization ('encode').
 -- enumToAvro :: (Show a, Enum a, Bounded a, Generic a) => a -> T.Value Type

--- a/src/Data/Avro/Decode.hs
+++ b/src/Data/Avro/Decode.hs
@@ -161,7 +161,7 @@ getAvroOf ty0 = go ty0
          case unionLookup i of
           Nothing -> fail $ "Decoded Avro tag is outside the expected range for a Union. Tag: " <> show i <> " union of: " <> show (P.map typeName $ NE.toList ts)
           Just t  -> T.Union ts t <$> go t
-    Fixed {..} -> T.Fixed <$> G.getByteString (fromIntegral size)
+    Fixed {..} -> T.Fixed ty <$> G.getByteString (fromIntegral size)
 
  getKVBlocks :: Type -> Get [[(Text,T.Value Type)]]
  getKVBlocks t =

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -75,6 +75,11 @@ genFromAvro (S.Record n _ _ _ _ fs) =
         fromAvro (AT.Record _ r) = $(genFromAvroFieldsExp (mkTextName $ unTN n) fs) r
         fromAvro value           = $( [|\v -> badValue v $(mkTextLit $ unTN n)|] ) value
   |]
+genFromAvro (S.Fixed n _ _ _) =
+  [d| instance FromAvro $(conT $ mkDataTypeName n) where
+        fromAvro (AT.Fixed _ v) = pure $ $(conE (mkDataTypeName n)) v
+        fromAvro value = $( [|\v -> badValue v $(mkTextLit $ unTN n)|] ) value
+  |]
 genFromAvro _                             = pure []
 
 genFromAvroFieldsExp :: Name -> [Field] -> Q Exp
@@ -99,7 +104,7 @@ genHasAvroSchema s = do
       |]
 
 genToAvro :: Schema -> Q [Dec]
-genToAvro s@(Enum n _ _ _ vs _) = do
+genToAvro s@(Enum n _ _ _ vs _) =
   toAvroInstance (mkSchemaValueName n)
   where
     conP' = flip conP [] . mkAdtCtorName n
@@ -123,6 +128,16 @@ genToAvro s@(Record n _ _ _ _ fs) =
         $(let assign fld = [| T.pack $(mkTextLit (fldName fld)) .= $(varE $ mkFieldTextName n fld) r |]
           in listE $ assign <$> fs
         )
+      |]
+
+genToAvro s@(Fixed n _ _ size) =
+  toAvroInstance (mkSchemaValueName n)
+  where
+    toAvroInstance sname =
+      [d| instance ToAvro $(conT $ mkDataTypeName n) where
+            toAvro = $(do
+              x <- newName "x"
+              lamE [conP (mkDataTypeName n) [varP x]] [| AT.Fixed $(varE sname) $(varE x) |])
       |]
 
 schemaDef :: Name -> Schema -> Q [Dec]
@@ -150,6 +165,10 @@ genType (S.Record n _ _ _ _ fs) = do
 genType (S.Enum n _ _ _ vs _) = do
   let dname = mkDataTypeName n
   sequenceA [genEnum dname (mkAdtCtorName n <$> vs)]
+genType (S.Fixed n _ _ s) = do
+  let dname = mkDataTypeName n
+  sequenceA [genNewtype dname]
+
 genType _ = pure []
 
 mkFieldTypeName :: S.Type -> Q TH.Type
@@ -212,6 +231,27 @@ mkField prefix field = do
   ftype <- mkFieldTypeName (fldType field)
   let fName = mkFieldTextName prefix field
   pure (fName, defaultStrictness, ftype)
+
+genNewtype :: Name -> Q Dec
+#if MIN_VERSION_template_haskell(2,12,0)
+genNewtype dn = do
+  ders <- sequenceA [[t|Eq|], [t|Show|]]
+  fldType <- [t|ByteString|]
+  let ctor = RecC dn [(mkName ("un" ++ nameBase dn), defaultStrictness, fldType)]
+  pure $ NewtypeD [] dn [] Nothing ctor [DerivClause Nothing ders]
+#elif MIN_VERSION_template_haskell(2,11,0)
+genNewtype dn = do
+  ders <- sequenceA [[t|Eq|], [t|Show|]]
+  fldType <- [t|ByteString|]
+  let ctor = RecC dn [(mkName ("un" ++ nameBase dn), defaultStrictness, fldType)]
+  pure $ NewtypeD [] dn [] Nothing ctor ders
+#else
+genNewtype dn = do
+  [ConT eq, ConT sh] <- sequenceA [[t|Eq|], [t|Show|]]
+  fldType <- [t|ByteString|]
+  let ctor = RecC dn [(mkName ("un" ++ nameBase dn), defaultStrictness, fldType)]
+  pure $ NewtypeD [] dn [] Nothing ctor [eq, sh]
+#endif
 
 genEnum :: Name -> [Name] -> Q Dec
 #if MIN_VERSION_template_haskell(2,12,0)

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -176,7 +176,7 @@ mkFieldTypeName :: S.Type -> Q TH.Type
 mkFieldTypeName t = case t of
   S.Boolean                     -> [t| Bool |]
   S.Long                        -> [t| Int64 |]
-  S.Int                         -> [t| Int |]
+  S.Int                         -> [t| Int32 |]
   S.Float                       -> [t| Float |]
   S.Double                      -> [t| Double |]
   S.Bytes                       -> [t| ByteString |]
@@ -251,7 +251,7 @@ genNewtype dn = do
   [ConT eq, ConT sh] <- sequenceA [[t|Eq|], [t|Show|]]
   fldType <- [t|ByteString|]
   let ctor = RecC dn [(mkName ("un" ++ nameBase dn), defaultStrictness, fldType)]
-  pure $ NewtypeD [] dn [] Nothing ctor [eq, sh]
+  pure $ NewtypeD [] dn [] ctor [eq, sh]
 #endif
 
 genEnum :: Name -> [Name] -> Q Dec

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -27,6 +27,7 @@ import           Language.Haskell.TH.Syntax
 
 import Data.Avro.Deriving.NormSchema
 
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy       as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBSC8
 import           Data.Text                  (Text)
@@ -75,9 +76,9 @@ genFromAvro (S.Record n _ _ _ _ fs) =
         fromAvro (AT.Record _ r) = $(genFromAvroFieldsExp (mkTextName $ unTN n) fs) r
         fromAvro value           = $( [|\v -> badValue v $(mkTextLit $ unTN n)|] ) value
   |]
-genFromAvro (S.Fixed n _ _ _) =
+genFromAvro (S.Fixed n _ _ s) =
   [d| instance FromAvro $(conT $ mkDataTypeName n) where
-        fromAvro (AT.Fixed _ v) = pure $ $(conE (mkDataTypeName n)) v
+        fromAvro (AT.Fixed _ v) | BS.length v == s = pure $ $(conE (mkDataTypeName n)) v
         fromAvro value = $( [|\v -> badValue v $(mkTextLit $ unTN n)|] ) value
   |]
 genFromAvro _                             = pure []

--- a/src/Data/Avro/Deriving/NormSchema.hs
+++ b/src/Data/Avro/Deriving/NormSchema.hs
@@ -28,6 +28,7 @@ extractDerivables s = flip evalState S.empty . normSchema rawRecs <$> rawRecs
       Union (t1 :| ts) _      -> getTypes t1 <> concatMap getTypes ts
       Map t                   -> getTypes t
       e@Enum{}                -> [e]
+      f@Fixed{}               -> [f]
       _                       -> []
 
 -- TODO: Currently ensures normalisation: only in one way

--- a/src/Data/Avro/Encode.hs
+++ b/src/Data/Avro/Encode.hs
@@ -233,5 +233,10 @@ instance EncodeAvro (T.Value Type) where
         case DL.elemIndex sel (NE.toList opts) of
           Just idx -> AvroM (putI idx <> putAvro val, S.mkUnion opts)
           Nothing  -> error "Union encoding specifies type not found in schema"
-      T.Fixed bs  -> avro bs
       T.Enum sch@S.Enum{..} ix t -> AvroM (putI ix, sch)
+      T.Fixed ty bs  ->
+        if (B.length bs == size ty)
+          then AvroM (byteString bs, S.Bytes)
+          else error $ "Fixed type "  <> show (name ty)
+                      <> " has size " <> show (size ty)
+                      <> " but the value has length " <> show (B.length bs)

--- a/src/Data/Avro/FromAvro.hs
+++ b/src/Data/Avro/FromAvro.hs
@@ -70,6 +70,11 @@ instance FromAvro Int64 where
 instance FromAvro Double where
   fromAvro (T.Double d) = pure d
   fromAvro v            = badValue v "Double"
+
+instance FromAvro Float where
+  fromAvro (T.Float f) = pure f
+  fromAvro v           = badValue v "Float"
+
 instance FromAvro a => FromAvro (Maybe a) where
   fromAvro (T.Union (S.Null :| [_])  _ T.Null) = pure Nothing
   fromAvro (T.Union (S.Null :| [_]) _ v)       = Just <$> fromAvro v

--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -45,6 +45,9 @@ instance HasAvroSchema Int64 where
 instance HasAvroSchema Double where
   schema = Tagged S.Double
 
+instance HasAvroSchema Float where
+  schema = Tagged S.Float
+
 instance HasAvroSchema Text.Text where
   schema = Tagged S.String
 

--- a/src/Data/Avro/ToAvro.hs
+++ b/src/Data/Avro/ToAvro.hs
@@ -47,6 +47,9 @@ instance ToAvro Int64 where
 instance ToAvro Double where
   toAvro = T.Double
 
+instance ToAvro Float where
+  toAvro = T.Float
+
 instance ToAvro Text.Text where
   toAvro = T.String
 

--- a/src/Data/Avro/Types.hs
+++ b/src/Data/Avro/Types.hs
@@ -20,6 +20,6 @@ data Value f
       | Map (HashMap Text (Value f))   -- ^ Dynamically enforced monomorphic type
       | Record f (HashMap Text (Value f)) -- Order and a map
       | Union (NonEmpty f) f (Value f) -- ^ Set of union options, schema for selected option, and the actual value.
-      | Fixed {-# UNPACK #-} !ByteString
+      | Fixed f {-# UNPACK #-} !ByteString
       | Enum f {-# UNPACK #-} !Int Text  -- ^ An enum is a set of the possible symbols (the schema) and the selected symbol
   deriving (Eq, Show)

--- a/stack-6.yaml
+++ b/stack-6.yaml
@@ -8,7 +8,8 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: [pure-zlib-0.6]
+extra-deps:
+- pure-zlib-0.6
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,8 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: [pure-zlib-0.6]
+extra-deps:
+- pure-zlib-0.6
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-9.6
+resolver: lts-9.21
 
 # Local packages, usually specified by relative directory name.
 packages:

--- a/test/Avro/Codec/FloatSpec.hs
+++ b/test/Avro/Codec/FloatSpec.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Avro.Codec.FloatSpec (spec) where
+
+import           Data.Avro
+import           Data.Avro.Schema
+import           Data.Tagged
+import           Test.Hspec
+import qualified Data.Avro.Types      as AT
+import qualified Data.ByteString.Lazy as BL
+import qualified Test.QuickCheck      as Q
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+newtype OnlyFloat = OnlyFloat
+  {onlyFloatValue :: Float
+  } deriving (Show, Eq)
+
+onlyFloatSchema :: Schema
+onlyFloatSchema =
+  let fld nm = Field nm [] Nothing Nothing
+  in Record "OnlyFloat" (Just "test.contract") [] Nothing Nothing
+        [ fld "onlyFloatValue" Float Nothing
+        ]
+
+instance HasAvroSchema OnlyFloat where
+  schema = pure onlyFloatSchema
+
+instance ToAvro OnlyFloat where
+  toAvro sa = record onlyFloatSchema
+    [ "onlyFloatValue" .= onlyFloatValue sa ]
+
+instance FromAvro OnlyFloat where
+  fromAvro (AT.Record _ r) =
+    OnlyFloat <$> r .: "onlyFloatValue"
+
+spec :: Spec
+spec = describe "Avro.Codec.FloatSpec" $ do
+  it "Can decode 0.89" $ do
+    let expectedBuffer = BL.pack [10, -41, 99, 63]
+    let value = OnlyFloat 0.89
+    encode value `shouldBe` expectedBuffer
+
+  it "Can decode -2.0" $ do
+    let expectedBuffer = BL.pack [0, 0, 0, -64]
+    let value = OnlyFloat (-2.0)
+    encode value `shouldBe` expectedBuffer
+
+  it "Can decode 1.0" $ do
+    let expectedBuffer = [0, 0, 128, 63]
+    let value = OnlyFloat 1.0
+    BL.unpack (encode value) `shouldBe` expectedBuffer
+
+  it "Can decode encoded Float values" $ do
+    Q.property $ \(d :: Float) ->
+        decode (encode (OnlyFloat d)) == Success (OnlyFloat d)

--- a/test/Avro/Codec/Int64Spec.hs
+++ b/test/Avro/Codec/Int64Spec.hs
@@ -19,7 +19,7 @@ import           Test.Hspec
 import qualified Data.Avro.Types      as AT
 import qualified Data.ByteString.Lazy as BL
 import qualified Test.QuickCheck      as Q
-import Debug.Trace
+
 {-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
 
 

--- a/test/Avro/THSimpleSpec.hs
+++ b/test/Avro/THSimpleSpec.hs
@@ -21,12 +21,14 @@ spec :: Spec
 spec = describe "Avro.THSpec: Small Schema" $ do
   let msgs =
         [ Endpoint
-          { endpointIps   = ["192.168.1.1", "127.0.0.1"]
-          , endpointPorts = [PortRange 1 10, PortRange 11 20]
+          { endpointIps    = ["192.168.1.1", "127.0.0.1"]
+          , endpointPorts  = [PortRange 1 10, PortRange 11 20]
+          , endpointOpaque = Opaque "16-b-long-string"
           }
         , Endpoint
           { endpointIps   = []
           , endpointPorts = [PortRange 1 10, PortRange 11 20]
+          , endpointOpaque = Opaque "opaque-long-text"
           }
         ]
 
@@ -39,4 +41,4 @@ spec = describe "Avro.THSpec: Small Schema" $ do
       let encoded = encode msg
       let decoded = decode encoded
 
-      pure msg `shouldBe` decoded
+      decoded `shouldBe` pure msg

--- a/test/Avro/THSimpleSpec.hs
+++ b/test/Avro/THSimpleSpec.hs
@@ -21,14 +21,16 @@ spec :: Spec
 spec = describe "Avro.THSpec: Small Schema" $ do
   let msgs =
         [ Endpoint
-          { endpointIps    = ["192.168.1.1", "127.0.0.1"]
-          , endpointPorts  = [PortRange 1 10, PortRange 11 20]
-          , endpointOpaque = Opaque "16-b-long-string"
+          { endpointIps         = ["192.168.1.1", "127.0.0.1"]
+          , endpointPorts       = [PortRange 1 10, PortRange 11 20]
+          , endpointOpaque      = Opaque "16-b-long-string"
+          , endpointCorrelation = Opaque "opaq-correlation"
           }
         , Endpoint
-          { endpointIps   = []
-          , endpointPorts = [PortRange 1 10, PortRange 11 20]
-          , endpointOpaque = Opaque "opaque-long-text"
+          { endpointIps         = []
+          , endpointPorts       = [PortRange 1 10, PortRange 11 20]
+          , endpointOpaque      = Opaque "opaque-long-text"
+          , endpointCorrelation = Opaque "correlation-data"
           }
         ]
 

--- a/test/Avro/THSimpleSpec.hs
+++ b/test/Avro/THSimpleSpec.hs
@@ -5,11 +5,17 @@ module Avro.THSimpleSpec
 where
 
 import           Control.Monad
-import           Data.Aeson (decodeStrict)
+import           Control.Lens
+import           Data.Aeson.Lens
 import           Data.Avro
 import           Data.Avro.Deriving
 import           Data.Avro.Schema
-import           Data.ByteString as BS
+import           Data.Monoid ((<>))
+import qualified Data.Aeson as J
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.ByteString.Base16 as Base16
 
 import Test.Hspec
 
@@ -25,16 +31,18 @@ spec = describe "Avro.THSpec: Small Schema" $ do
           , endpointPorts       = [PortRange 1 10, PortRange 11 20]
           , endpointOpaque      = Opaque "16-b-long-string"
           , endpointCorrelation = Opaque "opaq-correlation"
+          , endpointTag         = Left 14
           }
         , Endpoint
           { endpointIps         = []
           , endpointPorts       = [PortRange 1 10, PortRange 11 20]
           , endpointOpaque      = Opaque "opaque-long-text"
           , endpointCorrelation = Opaque "correlation-data"
+          , endpointTag         = Right "first-tag"
           }
         ]
 
-  it "should do roundtrip" $ do
+  it "should do roundtrip" $
     forM_ msgs $ \msg ->
       fromAvro (toAvro msg) `shouldBe` pure msg
 
@@ -44,3 +52,16 @@ spec = describe "Avro.THSpec: Small Schema" $ do
       let decoded = decode encoded
 
       decoded `shouldBe` pure msg
+
+  it "should convert to JSON" $ do
+    forM_ msgs $ \msg -> do
+      let json = J.encode (toAvro msg)
+      json ^? key "opaque" . _String      `shouldBe` Just (encodeOpaque $ endpointOpaque msg)
+      json ^? key "correlation" . _String `shouldBe` Just (encodeOpaque $ endpointCorrelation msg)
+
+      json ^? key "tag" . _Value . key "int" . _Integral   `shouldBe` endpointTag msg ^? _Left
+      json ^? key "tag" . _Value . key "string" . _String  `shouldBe` endpointTag msg ^? _Right
+    where
+      encodeOpaque :: Opaque -> Text
+      encodeOpaque v = "\\u" <> T.decodeUtf8 (Base16.encode $ unOpaque v)
+

--- a/test/Avro/ToAvroSpec.hs
+++ b/test/Avro/ToAvroSpec.hs
@@ -24,6 +24,8 @@ data TypesTestMessage = TypesTestMessage
   , tmTimestamp   :: Maybe Int64
   , tmForeignId   :: Maybe Int64
   , tmCompetence  :: Maybe Double
+  , tmRelevance   :: Maybe Float
+  , tmSeverity    :: Float
   , tmAttraction  :: Double
   } deriving (Show, Eq)
 
@@ -36,6 +38,8 @@ tmSchema =
         , fld "timestamp" (mkUnion (Null :| [Long])) Nothing
         , fld "foreignId" (mkUnion (Null :| [Long])) Nothing
         , fld "competence" (mkUnion (Null :| [Double])) Nothing
+        , fld "relevance" (mkUnion (Null :| [Float])) Nothing
+        , fld "severity" Float Nothing
         , fld "attraction" Double Nothing
         ]
 
@@ -49,6 +53,8 @@ instance ToAvro TypesTestMessage where
     , "timestamp"   .= tmTimestamp m
     , "foreignId"   .= tmForeignId m
     , "competence"  .= tmCompetence m
+    , "relevance"   .= tmRelevance m
+    , "severity"    .= tmSeverity m
     , "attraction"  .= tmAttraction m
     ]
 
@@ -59,6 +65,8 @@ instance FromAvro TypesTestMessage where
                      <*> r .: "timestamp"
                      <*> r .: "foreignId"
                      <*> r .: "competence"
+                     <*> r .: "relevance"
+                     <*> r .: "severity"
                      <*> r .: "attraction"
   fromAvro v = badValue v "TypesTestMessage"
 
@@ -69,6 +77,8 @@ message = TypesTestMessage
   , tmTimestamp  = Just 7
   , tmForeignId  = Nothing
   , tmCompetence = Just 7.5
+  , tmRelevance  = Just 3.8
+  , tmSeverity   = -255.77
   , tmAttraction = 8.974
   }
 

--- a/test/data/small.avsc
+++ b/test/data/small.avsc
@@ -10,6 +10,7 @@
         "size": 16
       }
     },
+    { "name": "correlation", "type": "Opaque" },
     {
       "name": "ips",
       "type": {

--- a/test/data/small.avsc
+++ b/test/data/small.avsc
@@ -4,19 +4,13 @@
   "fields": [
     {
       "name": "opaque",
-      "type": {
-        "name": "Opaque",
-        "type": "fixed",
-        "size": 16
-      }
+      "type": { "name": "Opaque", "type": "fixed", "size": 16 }
     },
     { "name": "correlation", "type": "Opaque" },
+    { "name": "tag", "type": ["int", "string"] },
     {
       "name": "ips",
-      "type": {
-        "type": "array",
-        "items": "string"
-      }
+      "type": { "type": "array", "items": "string" }
     },
     {
       "name": "ports",
@@ -26,14 +20,8 @@
           "type": "record",
           "name": "PortRange",
           "fields": [
-            {
-              "name": "start",
-              "type": "int"
-            },
-            {
-              "name": "end",
-              "type": "int"
-            }
+            { "name": "start", "type": "int" },
+            { "name": "end", "type": "int" }
           ]
         }
       }

--- a/test/data/small.avsc
+++ b/test/data/small.avsc
@@ -3,6 +3,14 @@
   "name": "Endpoint",
   "fields": [
     {
+      "name": "opaque",
+      "type": {
+        "name": "Opaque",
+        "type": "fixed",
+        "size": 16
+      }
+    },
+    {
       "name": "ips",
       "type": {
         "type": "array",


### PR DESCRIPTION
## Changes

- Added `FromAvro` and `ToAvro` instances for `Float` (the type was supported before, only instances were missing)
- Added support for `Fixed` type when deriving data types from schema
- Unit tests