### PR TITLE
Fixed how we handle unions of records with the same fields.

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -13,7 +13,11 @@ maintainer:          Alexey Raga <alexey.raga@gmail.com>
 -- copyright:
 category:            Data
 build-type:          Simple
-extra-source-files:  ChangeLog.md, test/data/reused.avsc, test/data/small.avsc, test/data/enums.avsc
+extra-source-files:  ChangeLog.md
+                   , test/data/reused.avsc
+                   , test/data/small.avsc
+                   , test/data/enums.avsc
+                   , test/data/unions.avsc
 cabal-version:       >=1.10
 
 source-repository head

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -111,7 +111,8 @@ instance Eq Type where
   Array ty == Array ty2 = ty == ty2
   Map ty == Map ty2 = ty == ty2
   NamedType t == NamedType t2 = t == t2
-  Record _ _ _ _ _ fs == Record _ _ _ _ _ fs2 = fs == fs2
+  Record name1 ns1 _ _ _ fs1 == Record name2 ns2 _ _ _ fs2 =
+    and [name1 == name2, ns1 == ns2, fs1 == fs2]
   Enum _ _ _ _ s _ == Enum _ _ _ _ s2 _ = s == s2
   Union a _ == Union b _ = a == b
   Fixed _ _ _ s == Fixed _ _ _ s2 = s == s2

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+module Avro.THUnionSpec
+where
+
+import           Data.Avro
+import           Data.Avro.Deriving
+
+import           Test.Hspec
+
+deriveAvro "test/data/unions.avsc"
+
+spec :: Spec
+spec = describe "Avro.THUnionSpec: Schema with unions." $ do
+  let objA = Unions
+        { unionsScalars = Left "foo"
+        , unionsNullable = Nothing
+        , unionsRecords = Left $ Foo { fooStuff = "stuff" }
+        , unionsSameFields = Left $ Foo { fooStuff = "more stuff" }
+        }
+      objB = Unions
+        { unionsScalars = Right 42
+        , unionsNullable = Just 37
+        , unionsRecords = Right $ Bar { barStuff = "stuff"
+                                      , barThings = Foo { fooStuff = "things" }
+                                      }
+        , unionsSameFields = Right $ NotFoo { notFooStuff = "different from Foo" }
+        }
+  it "records with unions should roundtrip" $ do
+    fromAvro (toAvro objA) `shouldBe` pure objA
+    fromAvro (toAvro objB) `shouldBe` pure objB

--- a/test/data/unions.avsc
+++ b/test/data/unions.avsc
@@ -1,0 +1,46 @@
+{ "type" : "record",
+  "name" : "Unions",
+  "namespace" : "haskell.avro.example",
+  "fields" : [
+    { "name" : "scalars",
+      "type" : ["string", "long"]
+    },
+    { "name" : "nullable",
+      "type" : ["null", "int"]
+    },
+    { "name" : "records",
+      "type" : [
+        { "type" : "record",
+          "name" : "Foo",
+          "fields" : [
+            { "name" : "stuff",
+              "type" : "string"
+            }
+          ]
+        },
+        { "type" : "record",
+          "name" : "Bar",
+          "fields" : [
+            { "name" : "stuff",
+              "type" : "string"
+            },
+            { "name" : "things",
+              "type" : "Foo"
+            }
+          ]
+        }
+      ]
+    },
+    { "name" : "sameFields",
+      "type" : [
+        "Foo",
+        { "type" : "record",
+          "name" : "NotFoo",
+          "fields" : [
+            { "name" : "stuff", "type" : "string" }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
When deserializing an Avro object, we need to select records based on their names, not just their fields. This lets us have unions with two records that have different names but the same set of fields (which is totally valid in Avro).

In principle, we can select named types based *only* on names, not looking at the fields at all. Avro requires full names in schemas to be unique. However, I did not make this change here to avoid changing the existing behavior of the library too much.