### PR TITLE
Fixed how default values are parsed for bytes and fixed types.

### DIFF
--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeSynonymInstances  #-}
+{-# LANGUAGE ViewPatterns          #-}
 -- | Avro 'Schema's, represented here as values of type 'Schema',
 -- describe the serialization and de-serialization of values.
 --
@@ -22,6 +23,8 @@ module Data.Avro.Schema
   , typeName
   , buildTypeEnvironment
   , Result(..)
+  , parseBytes
+  , serializeBytes
   ) where
 
 import           Control.Applicative
@@ -33,7 +36,9 @@ import           Data.Aeson                 (FromJSON (..), ToJSON (..), object,
 import qualified Data.Aeson                 as A
 import           Data.Aeson.Types           (Parser, typeMismatch)
 import qualified Data.Avro.Types            as Ty
+import qualified Data.ByteString            as B
 import qualified Data.ByteString.Base16     as Base16
+import qualified Data.Char                  as Char
 import           Data.Hashable
 import qualified Data.HashMap.Strict        as HashMap
 import           Data.Int
@@ -371,17 +376,24 @@ parseAvroJSON env (NamedType (TN tn)) av =
     Just t  -> parseAvroJSON env t av
 parseAvroJSON env ty av =
     case av of
-      A.String s     ->
+      A.String s      ->
         case ty of
-          String    -> return $ Ty.String s
-          Enum {..} ->
+          String      -> return $ Ty.String s
+          Enum {..}   ->
               if s `elem` symbols
                 then return $ Ty.Enum ty (maybe (error "IMPOSSIBLE BUG") id $ lookup s (zip symbols [0..])) s
                 else fail $ "JSON string is not one of the expected symbols for enum '" <> show name <> "': " <> T.unpack s
+          Bytes       -> Ty.Bytes <$> parseBytes s
+          Fixed {..}  -> do
+            bytes <- parseBytes s
+            let len = B.length bytes
+            when (len /= size) $
+              fail $ "Fixed string wrong size. Expected " <> show size <> " but got " <> show len
+            return $ Ty.Fixed ty bytes
           Union tys _ -> do
             f <- tryAllTypes env tys av
             maybe (fail $ "No match for String in union '" <> show (typeName ty) <> "'.") pure f
-          _ -> avroTypeMismatch ty "string"
+          _           -> avroTypeMismatch ty "string"
       A.Bool b       -> case ty of
                           Boolean -> return $ Ty.Boolean b
                           _       -> avroTypeMismatch ty "boolean"
@@ -421,6 +433,21 @@ parseAvroJSON env ty av =
                   Null -> return Ty.Null
                   Union us _ | Null `elem` NE.toList us -> return $ Ty.Union us Null Ty.Null
                   _ -> avroTypeMismatch ty "null"
+
+-- | Parses a string literal into a bytestring in the format expected
+-- for bytes and fixed values. Will fail if every character does not
+-- have a codepoint between 0 and 255.
+parseBytes :: Text -> Result B.ByteString
+parseBytes bytes = case T.find (not . inRange) bytes of
+  Just badChar -> fail $ "Invalid character in bytes or fixed string representation: " <> show badChar
+  Nothing      -> return $ B.pack $ fromIntegral . Char.ord <$> T.unpack bytes
+  where inRange (Char.ord -> c) = c >= 0x00 && c <= 0xFF
+
+-- | Turn a 'ByteString' into a 'Text' that matches the format Avro
+-- expects from bytes and fixed literals in JSON. Each byte is mapped
+-- to a single Unicode codepoint between 0 and 255.
+serializeBytes :: B.ByteString -> Text
+serializeBytes = T.pack . map (Char.chr . fromIntegral ) . B.unpack
 
 tryAllTypes :: (Text -> Maybe Type) -> NonEmpty Type -> A.Value -> Result (Maybe (Ty.Value Type))
 tryAllTypes env tys av =

--- a/test/data/maybe.avsc
+++ b/test/data/maybe.avsc
@@ -1,7 +1,19 @@
 {
-    "type": "record",
-    "name": "MaybeTest",
-    "fields": [
-      { "name": "tag", "type": ["null", "string"], "default": null }
-    ]
-  }
+  "type": "record",
+  "name": "MaybeTest",
+  "fields": [
+    { "name": "tag", "type": ["null", "string"], "default": null },
+    { "name": "fixedTag",
+      "type": {
+        "type": "fixed",
+        "name": "FixedTag",
+        "size": 3
+      },
+      "default": "\u0000\u002a\u00ff"
+    },
+    { "name": "bytesTag",
+      "type": "bytes",
+      "default": "\u0000\u0025\u00ff"
+    }
+  ]
+}


### PR DESCRIPTION
Addressed #18

Default values for bytes objects are encoded as JSON string literals where each codepoint is between 0 and 255 and directly represents a byte.

The biggest change here actually involves Template Haskell. The previous deriving code generated schemas by encoding the schema to JSON at compile time, embedding it as a string literal and parsing it at runtime. This caused problems with the encoding of bytes and generally seemed error-prone, so I replaced it with a whole bunch of TH code to generate the Schema object directly.

These changes are tested by extending `maybe.avsc` to have a `Fixed` and `Bytes` field with default values attached.