### PR TITLE
Fix union default values

### DIFF
--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -209,6 +209,7 @@ schemaDef sname sch = setName sname $
                     , fldDefault = $(fromMaybe [e|Nothing|] $ mkJust . mkDefaultValue <$> fldDefault)
                     }
             |]
+        wrapUnion ts@(t :| _) value = AT.Union ts t <$> value
 
         mkJust exp = [e|Just $(exp)|]
 
@@ -224,7 +225,7 @@ schemaDef sname sch = setName sname $
           AT.Array vec    -> [e| AT.Array $ V.fromList $(ListE <$> mapM mkDefaultValue (V.toList vec)) |]
           AT.Map m        -> [e| AT.Map $ $(mkMap m) |]
           AT.Record s m   -> [e| AT.Record $(mkSchema s) $(mkMap m) |]
-          AT.Union _ _ v  -> mkDefaultValue v
+          AT.Union ts t v -> [e| AT.Union $(mkNE ts) $(mkSchema t) $(mkDefaultValue v) |]
           AT.Fixed s bs   -> [e| AT.Fixed $(mkSchema s) $(mkByteString bs) |]
           AT.Enum s n sym -> [e| AT.Enum $(mkSchema s) $(litE $ IntegerL $ fromIntegral n) $(mkText sym) |]
 

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -209,7 +209,6 @@ schemaDef sname sch = setName sname $
                     , fldDefault = $(fromMaybe [e|Nothing|] $ mkJust . mkDefaultValue <$> fldDefault)
                     }
             |]
-        wrapUnion ts@(t :| _) value = AT.Union ts t <$> value
 
         mkJust exp = [e|Just $(exp)|]
 

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -383,8 +383,8 @@ instance Traversable Result where
 -- of the first type in the union.
 parseFieldDefault :: (Text -> Maybe Type) -> Type -> A.Value -> Result (Ty.Value Type)
 parseFieldDefault env schema value = parseAvroJSON defaultUnion env schema value
-  where defaultUnion (Union (t :| _) _) val = parseFieldDefault env t val
-        defaultUnion _ _                    = error "Impossible: not Union."
+  where defaultUnion (Union ts@(t :| _) _) val = Ty.Union ts t <$> parseFieldDefault env t val
+        defaultUnion _ _                       = error "Impossible: not Union."
 
 -- | Parse JSON-encoded avro data.
 parseAvroJSON :: (Type -> A.Value -> Result (Ty.Value Type))

--- a/test/Avro/DefaultsSpec.hs
+++ b/test/Avro/DefaultsSpec.hs
@@ -10,6 +10,7 @@ import           Data.Avro.Deriving
 import           Data.Avro.Schema
 import qualified Data.Avro.Types     as Ty
 import qualified Data.HashMap.Strict as M
+import           Data.List.NonEmpty  (NonEmpty (..))
 import qualified Data.Vector         as V
 
 import           Test.Hspec
@@ -33,7 +34,7 @@ spec = describe "Avro.DefaultsSpec: Schema with named types" $ do
       msgSchema = schemaOf (undefined :: MaybeTest)
       fixedSchema = schemaOf (undefined :: FixedTag)
       defaults = fldDefault <$> fields msgSchema
-    in defaults `shouldBe` [ Just Ty.Null
+    in defaults `shouldBe` [ Just $ Ty.Union (Null :| [String]) Null Ty.Null
                            , Just $ Ty.Fixed fixedSchema "\0\42\255"
                            , Just $ Ty.Bytes "\0\37\255"
                            ]

--- a/test/Avro/THUnionSpec.hs
+++ b/test/Avro/THUnionSpec.hs
@@ -4,8 +4,12 @@
 module Avro.THUnionSpec
 where
 
+import qualified Data.List.NonEmpty as NE
+
 import           Data.Avro
 import           Data.Avro.Deriving
+import qualified Data.Avro.Schema   as Schema
+import qualified Data.Avro.Types    as Avro
 
 import           Test.Hspec
 
@@ -27,6 +31,29 @@ spec = describe "Avro.THUnionSpec: Schema with unions." $ do
                                       }
         , unionsSameFields = Right $ NotFoo { notFooStuff = "different from Foo" }
         }
+
+      field name schema def = Schema.Field name [] Nothing (Just Schema.Ascending) schema def
+      record name namespace fields =
+        Schema.Record name namespace [] Nothing (Just Schema.Ascending) fields
+      named = Schema.NamedType . Schema.TN
+
+      expectedSchema = record "Unions" (Just "haskell.avro.example")
+        [ field "scalars"    (Schema.mkUnion (NE.fromList [Schema.String, Schema.Long])) scalarsDefault
+        , field "nullable"   (Schema.mkUnion (NE.fromList [Schema.Null, Schema.Int]))    nullableDefault
+        , field "records"    (Schema.mkUnion (NE.fromList [fooSchema, barSchema]))       Nothing
+        , field "sameFields" (Schema.mkUnion (NE.fromList [named "Foo", notFooSchema]))  Nothing
+        ]
+      scalarsDefault  = Just $ Avro.Union (NE.fromList [Schema.String, Schema.Long]) Schema.String (Avro.String "foo")
+      nullableDefault = Just $ Avro.Union (NE.fromList [Schema.Null, Schema.Int])    Schema.Null   Avro.Null
+
+      fooSchema = record "Foo" Nothing [field "stuff" Schema.String Nothing]
+      barSchema = record "Bar" Nothing
+        [ field "stuff"  Schema.String Nothing
+        , field "things" (named "Foo") Nothing
+        ]
+      notFooSchema = record "NotFoo" Nothing [field "stuff" Schema.String Nothing]
+  it "produces valid schemas" $ do
+    schema'Unions `shouldBe` expectedSchema
   it "records with unions should roundtrip" $ do
     fromAvro (toAvro objA) `shouldBe` pure objA
     fromAvro (toAvro objB) `shouldBe` pure objB

--- a/test/data/unions.avsc
+++ b/test/data/unions.avsc
@@ -3,10 +3,12 @@
   "namespace" : "haskell.avro.example",
   "fields" : [
     { "name" : "scalars",
-      "type" : ["string", "long"]
+      "type" : ["string", "long"],
+      "default" : "foo"
     },
     { "name" : "nullable",
-      "type" : ["null", "int"]
+      "type" : ["null", "int"],
+      "default" : null
     },
     { "name" : "records",
       "type" : [


### PR DESCRIPTION
This prevents a spurious schema mismatch when using the default value for a field whose type is a union. (Addresses issue #25.)

The logic needed updating in two places:

  * the code that parses schemas from JSON
  * the Template Haskell code that generates types from schemas

I added tests that check whether default values for unions are rendered correctly for both cases. While the TH code *does* use the `FromJSON` instance of `Schema` internally, it is probably worth adding more tests *just* for the JSON parsing, maybe using the same pattern I did here. I figure that's out of scope for this PR though, and I don't have time to do it today.

(Also, there is probably a way to reorganize the tests to make them easier to navigate and to have less redundant code...)