### PR TITLE
Fix encoding empty containers

### DIFF
--- a/src/Data/Avro/HasAvroSchema.hs
+++ b/src/Data/Avro/HasAvroSchema.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 module Data.Avro.HasAvroSchema where
 
+import qualified Data.Array           as Ar
 import           Data.Avro.Schema     as S
 import           Data.Avro.Types      as T
 import qualified Data.ByteString      as B
@@ -10,22 +12,37 @@ import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.HashMap.Strict  as HashMap
 import           Data.Int
+import           Data.Ix              (Ix)
+import           Data.List.NonEmpty   (NonEmpty (..))
 import qualified Data.Map             as Map
 import           Data.Monoid          ((<>))
+import           Data.Proxy
+import qualified Data.Set             as S
+import           Data.Tagged
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
-import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Text.Lazy       as TL
-import           Data.Tagged
 import qualified Data.Vector          as V
+import qualified Data.Vector.Unboxed  as U
 import           Data.Word
-import Data.Proxy
 
 class HasAvroSchema a where
   schema :: Tagged a Type
 
 schemaOf :: (HasAvroSchema a) => a -> Type
 schemaOf = witness schema
+
+instance HasAvroSchema Word8 where
+  schema = Tagged S.Int
+
+instance HasAvroSchema Word16 where
+  schema = Tagged S.Int
+
+instance HasAvroSchema Word32 where
+  schema = Tagged S.Long
+
+instance HasAvroSchema Word64 where
+  schema = Tagged S.Long
 
 instance HasAvroSchema Bool where
   schema = Tagged S.Boolean
@@ -35,6 +52,12 @@ instance HasAvroSchema () where
 
 instance HasAvroSchema Int where
   schema = Tagged S.Long
+
+instance HasAvroSchema Int8 where
+  schema = Tagged S.Int
+
+instance HasAvroSchema Int16 where
+  schema = Tagged S.Int
 
 instance HasAvroSchema Int32 where
   schema = Tagged S.Int
@@ -85,6 +108,18 @@ instance (HasAvroSchema a) => HasAvroSchema (Maybe a) where
   schema = Tagged $ mkUnion (S.Null:| [untag (schema :: Tagged a Type)])
 
 instance (HasAvroSchema a) => HasAvroSchema [a] where
+  schema = wrapTag S.Array (schema :: Tagged a Type)
+
+instance (HasAvroSchema a, Ix i) => HasAvroSchema (Ar.Array i a) where
+  schema = wrapTag S.Array (schema :: Tagged a Type)
+
+instance HasAvroSchema a => HasAvroSchema (V.Vector a) where
+  schema = wrapTag S.Array (schema :: Tagged a Type)
+
+instance HasAvroSchema a => HasAvroSchema (U.Vector a) where
+  schema = wrapTag S.Array (schema :: Tagged a Type)
+
+instance HasAvroSchema a => HasAvroSchema (S.Set a) where
   schema = wrapTag S.Array (schema :: Tagged a Type)
 
 wrapTag :: (Type -> Type) -> Tagged a Type -> Tagged b Type


### PR DESCRIPTION
## Changes

#### Allowed encoding empty containers
Previously encoding empty set of chunks into a container would fail with a nasty `Prelude.head` error.
It was due to the following line:
```
objSchema    = getSchema (P.head (P.head xss))
```

Current version allows encoding empty chunks because the schema is now being passed into an internal encoding function (`Avro.Encode.encodeContainer` and `Avro.Encode.encodeContainerWithSync`).

Their public wrapper API `Data.Avro.encodeContainer` now takes the schema from a provided `ToAvro a` and passes it through, so there is no need to take an element from a possibly empty list(s) anymore.

#### Updated `Data.Avro.decodeContainer` signature.
To match `decode/decodeWithSchema` I have updated the signature for `decodeContainer`.
Now there are two functions:

This one is renamed from `decodeContainer`:
```
decodeContainerWithSchema :: FromAvro a => Schema -> ByteString -> [[a]]
```
It ignores the schema that is attached to `a` via `FromAvro a` and uses the one that is being passed explicitly (mirroring `decodeWithSchema` behaviour).

This one is a new `decodeContainer`:
```
decode ::  FromAvro a => ByteString -> Result a
```
It uses the schema that is attached to `a` via `FromAvro a` as a reader schema (mirroring `decode`).

@TikhonJelvis I think you may use containers, please have a look and let me know if this rename is not OK with you.
