### PR TITLE
Support Logical Types in a schema by dropping through to the underlying type

### DIFF
--- a/test/Avro/THLogicalTypeSpec.hs
+++ b/test/Avro/THLogicalTypeSpec.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+module Avro.THLogicalTypeSpec
+where
+
+import           Control.Lens
+import           Control.Monad
+
+import qualified Data.Aeson         as J
+import           Data.Aeson.Lens
+import qualified Data.ByteString    as B
+import qualified Data.Char          as Char
+import           Data.Monoid        ((<>))
+import           Data.Text          (Text)
+import qualified Data.Text          as T
+
+import           Test.Hspec
+
+import           Data.Avro
+import           Data.Avro.Deriving
+import           Data.Avro.Schema
+
+deriveAvro "test/data/logical.avsc"
+
+spec :: Spec
+spec = describe "Avro.THSpec: Logical Type Schema" $ do
+  let msgs =
+        [ Logical 12345
+        , Logical 67890
+        ]
+
+  it "should do roundtrip" $
+    forM_ msgs $ \msg ->
+      fromAvro (toAvro msg) `shouldBe` pure msg
+
+  it "should do full round trip" $
+    forM_ msgs $ \msg -> do
+      let encoded = encode msg
+      let decoded = decode encoded
+
+      decoded `shouldBe` pure msg

--- a/test/data/logical.avsc
+++ b/test/data/logical.avsc
@@ -1,0 +1,12 @@
+{
+  "name": "Logical",
+  "type": "record",
+  "fields": [{
+    "name": "timestamp",
+    "type":
+      {
+        "logicalType": "timestamp-millis",
+        "type": "long"
+      }
+  }]
+}


### PR DESCRIPTION
The avro spec (https://avro.apache.org/docs/1.8.1/spec.html#Logical+Types) says:

"Language implementations must ignore unknown logical types when reading, and should use the underlying Avro type."

This change supports logical types by ignoring all of them. Something that's not clear to me is where the test should live for support for ignoring logical types. I'm open to pointers before this PR is ready for merge.