### PR TITLE
Enable CCI for nightly LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ workflows:
       - lts-7
       - lts-9
       - lts-11
-      # - nightly
+      - nightly
       - release:
           requires:
             - lts-7

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- pure-zlib-0.6
+- pure-zlib-0.6.4
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Bump `pure-zlib` version, enable CCI for GHC-8.4 (via `nightly` resolver).
Closes https://github.com/GaloisInc/avro/issues/35