### PR TITLE
Container ops

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 307ace222c16e9660fc8fd8f1d3b126a4254daea39bb616b93782a86b81d73b0
+-- hash: 2c6985354c8e4acdcb47a9ff7d72b5ef4ec0999438aa2fe26ee2cd87faf2074d
 
 name:           avro
 version:        0.3.4.2
@@ -121,6 +121,7 @@ test-suite test
       Avro.Codec.TextSpec
       Avro.Codec.ZigZagSpec
       Avro.Decode.Lazy.ContainerSpec
+      Avro.Decode.Lazy.RawBlocksSpec
       Avro.Decode.Lazy.ValuesSpec
       Avro.Deconflict.Reader
       Avro.Deconflict.Writer

--- a/src/Data/Avro.hs
+++ b/src/Data/Avro.hs
@@ -72,6 +72,7 @@ module Data.Avro
   ( FromAvro(..)
   , ToAvro(..)
   , HasAvroSchema(..)
+  , Schema
   , Avro
   , (.:)
   , (.=), record, fixed

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -13,6 +13,9 @@ module Data.Avro.Decode.Lazy
   , decodeContainerWithSchema
   , decodeContainerWithSchema'
 
+  -- * Bypass decoding
+  , decodeRawBlocks
+
   -- * Lower level interface
   , getContainerValues
   , getContainerValuesWith
@@ -30,11 +33,11 @@ import           Data.Binary.IEEE754              as IEEE
 import           Data.Bits
 import           Data.ByteString                  (ByteString)
 import qualified Data.ByteString.Lazy             as BL
-import qualified Data.ByteString.Lazy.Char8       as BC
+import qualified Data.ByteString.Lazy.Char8       as BL
 import           Data.Either                      (isRight)
 import qualified Data.HashMap.Strict              as HashMap
 import           Data.Int
-import           Data.List                        (foldl')
+import           Data.List                        (foldl', unfoldr)
 import qualified Data.List.NonEmpty               as NE
 import qualified Data.Map                         as Map
 import           Data.Maybe
@@ -57,6 +60,8 @@ import           Data.Avro.Decode.Get
 import           Data.Avro.Decode.Lazy.Convert    (toStrictValue)
 import           Data.Avro.Decode.Lazy.Deconflict as C
 import           Data.Avro.FromAvro
+
+import           Debug.Trace
 
 -- | Decodes the container as a lazy list of values of the requested type.
 --
@@ -132,9 +137,55 @@ decodeAvro s = snd . getAvroOf s
 --
 -- The "outer" error represents the error in opening the container itself
 -- (including problems like reading schemas embedded into the container.)
-getContainerValues :: BC.ByteString -> Either String (Schema, [[T.LazyValue Type]])
+getContainerValues :: BL.ByteString -> Either String (Schema, [[T.LazyValue Type]])
 getContainerValues = getContainerValuesWith getAvroOf
 {-# INLINABLE getContainerValues #-}
+
+decodeRawBlocks :: BL.ByteString -> Either String (Schema, [Either String BL.ByteString])
+decodeRawBlocks bs =
+  case runGetOrFail getAvro bs of
+    Left (bs', _, err) -> Left err
+    Right (bs', _, ContainerHeader {..}) ->
+      let blocks = allBlocks syncBytes decompress bs'
+      in Right (containedSchema, blocks)
+  where
+    allBlocks sync decompress bytes =
+      flip unfoldr (Just bytes) $ \acc -> case acc of
+        Just rest -> next sync decompress rest
+        Nothing   -> Nothing
+
+    next syncBytes decompress bytes =
+      case getNextBlock syncBytes decompress bytes of
+        Right (Just (_, block, rest)) -> Just (Right block, Just rest)
+        Right Nothing                 -> Nothing
+        Left err                      -> Just (Left err, Nothing)
+
+getNextBlock :: BL.ByteString
+             -> (BL.ByteString -> Get BL.ByteString)
+             -> BL.ByteString
+             -> Either String (Maybe (Int, BL.ByteString, BL.ByteString))
+getNextBlock sync decompress bs =
+  if BL.null bs
+    then Right Nothing
+    else case runGetOrFail (getRawBlock decompress) bs of
+      Left (bs', _, err)             -> Left err
+      Right (bs', _, (nrObj, bytes)) ->
+        case checkMarker sync bs' of
+          Left err   -> Left err
+          Right rest -> Right $ Just (nrObj, bytes, rest)
+  where
+    getRawBlock :: (BL.ByteString -> Get BL.ByteString) -> Get (Int, BL.ByteString)
+    getRawBlock decompress = do
+      nrObj    <- getLong >>= sFromIntegral
+      nrBytes  <- getLong
+      bytes    <- G.getLazyByteString nrBytes >>= decompress
+      pure (nrObj, bytes)
+
+    checkMarker :: BL.ByteString -> BL.ByteString -> Either String BL.ByteString
+    checkMarker sync bs =
+      case BL.splitAt nrSyncBytes bs of
+        (marker, _) | marker /= sync -> Left "Invalid marker, does not match sync bytes."
+        (_, rest) -> Right rest
 
 getContainerValuesWith :: (Schema -> BL.ByteString -> (BL.ByteString, T.LazyValue Type))
                  -> BL.ByteString
@@ -146,7 +197,7 @@ getContainerValuesWith schemaToGet bs =
     Right (bs', _, ContainerHeader {..}) ->
       Right (containedSchema, snd $ getBlocks (schemaToGet containedSchema) syncBytes bs' decompress)
   where
-    getRawBlock :: (BL.ByteString -> Get BL.ByteString) -> Get (Int, BC.ByteString)
+    getRawBlock :: (BL.ByteString -> Get BL.ByteString) -> Get (Int, BL.ByteString)
     getRawBlock decompress = do
       nrObj    <- getLong >>= sFromIntegral
       nrBytes  <- getLong

--- a/src/Data/Avro/Encode.hs
+++ b/src/Data/Avro/Encode.hs
@@ -71,6 +71,7 @@ encodeContainer sch xss =
   do sync <- newSyncBytes
      return $ encodeContainerWithSync sch sync xss
 
+-- | Creates an Avro container header for a given schema.
 containerHeaderWithSync :: Schema -> BL.ByteString -> Builder
 containerHeaderWithSync sch syncBytes =
   lazyByteString avroMagicBytes <>
@@ -96,12 +97,6 @@ encodeContainerWithSync sch syncBytes xss =
        putAvro nrBytes <>
        lazyByteString theBytes <>
        lazyByteString syncBytes
-
-
--- XXX make an instance 'EncodeAvro Schema'
--- Would require a schema schema...
--- encodeSchema :: EncodeAvro a => a -> BL.ByteString
--- encodeSchema = toLazyByteString . putAvro . getSchema
 
 putAvro :: EncodeAvro a => a -> Builder
 putAvro = fst . runAvro . avro

--- a/test/Avro/Decode/Lazy/RawBlocksSpec.hs
+++ b/test/Avro/Decode/Lazy/RawBlocksSpec.hs
@@ -31,14 +31,14 @@ spec = describe "Avro.Decode.Lazy.RawBlocksSpec" $ do
     container <- A.encodeContainer [mkEndpoint <$> [1, 2]]
     let Right (s, bs) = DL.decodeRawBlocks container
     s `shouldBe` schema'Endpoint
-    length bs `shouldBe` 1
+    fmap fst <$> bs `shouldBe` [Right 2]
     sequence bs `shouldSatisfy` isRight
 
   it "should decode container with multiple blocks" $ do
     container <- A.encodeContainer (chunksOf 4 $ mkEndpoint <$> [1..10])
     let Right (s, bs) = DL.decodeRawBlocks container
     s `shouldBe` schema'Endpoint
-    length bs `shouldBe` 3
+    fmap fst <$> bs `shouldBe` [Right 4, Right 4, Right 2]
     sequence bs `shouldSatisfy` isRight
 
 mkEndpoint :: Int -> Endpoint

--- a/test/Avro/Decode/Lazy/RawBlocksSpec.hs
+++ b/test/Avro/Decode/Lazy/RawBlocksSpec.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+module Avro.Decode.Lazy.RawBlocksSpec
+where
+
+import           Data.Avro                     as A
+import           Data.Avro.Decode.Lazy         as DL
+import           Data.Avro.Decode.Lazy.Convert as TC
+import           Data.Avro.Deriving
+import           Data.Either                   (isLeft, isRight)
+import           Data.List                     (unfoldr)
+import           Data.Semigroup                ((<>))
+import           Data.Text                     (pack)
+
+import           Test.Hspec
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+deriveAvro "test/data/small.avsc"
+
+spec :: Spec
+spec = describe "Avro.Decode.Lazy.RawBlocksSpec" $ do
+
+  it "should decode empty container" $ do
+    empty <- A.encodeContainer ([] :: [[Endpoint]])
+    DL.decodeRawBlocks empty `shouldBe` Right (schema'Endpoint, [])
+
+  it "should decode container with one block" $ do
+    container <- A.encodeContainer [mkEndpoint <$> [1, 2]]
+    let Right (s, bs) = DL.decodeRawBlocks container
+    s `shouldBe` schema'Endpoint
+    length bs `shouldBe` 1
+    sequence bs `shouldSatisfy` isRight
+
+  it "should decode container with multiple blocks" $ do
+    container <- A.encodeContainer (chunksOf 4 $ mkEndpoint <$> [1..10])
+    let Right (s, bs) = DL.decodeRawBlocks container
+    s `shouldBe` schema'Endpoint
+    length bs `shouldBe` 3
+    sequence bs `shouldSatisfy` isRight
+
+mkEndpoint :: Int -> Endpoint
+mkEndpoint i =
+  Endpoint
+    { endpointIps         = ["192.168.1." <> pack (show i), "127.0.0." <> pack (show i)]
+    , endpointPorts       = [PortRange 1 10, PortRange 11 20]
+    , endpointOpaque      = Opaque "16-b-long-string"
+    , endpointCorrelation = Opaque "opaq-correlation"
+    , endpointTag         = Left (fromIntegral i)
+    }
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf n = takeWhile (not.null) . unfoldr (Just . splitAt n)


### PR DESCRIPTION
This PR adds functionality to manipulate containers without necessarily encoding/decoding Avro values.
For example, merging two (or more) containers into one should not require re-encoding values.
 
In this PR:
- Read raw (serialised) block values from Avro containers.
- Pack a list of serialised blocks into an Avro container.
- Pack a list of already serialised individual values into an Avro container.

This functionality is not perfect since our library currently doesn't support compression when writing containers. This should be investigated and added as a separate ticket.