### PR TITLE
Reinstated TH support for unions with 3–5 branches.

### DIFF
--- a/test/Avro/JSONSpec.hs
+++ b/test/Avro/JSONSpec.hs
@@ -10,6 +10,7 @@ import qualified Data.Aeson           as Aeson
 import qualified Data.ByteString.Lazy as LBS
 
 import           Data.Avro.Deriving
+import           Data.Avro.EitherN
 import           Data.Avro.JSON
 
 import           Test.Hspec
@@ -67,18 +68,24 @@ spec = describe "Avro.JSONSpec: JSON serialization/parsing" $ do
     let expected = EnumWrapper 37 "blarg" EnumReasonInstead
     parseJSON enumsExampleJSON `shouldBe` pure expected
   let unionsExampleA = Unions
-        { unionsScalars = Left "blarg"
-        , unionsNullable = Nothing
-        , unionsRecords = Left $ Foo { fooStuff = "stuff" }
+        { unionsScalars    = Left "blarg"
+        , unionsNullable   = Nothing
+        , unionsRecords    = Left $ Foo { fooStuff = "stuff" }
         , unionsSameFields = Left $ Foo { fooStuff = "foo stuff" }
+        , unionsThree      = E3_1 37
+        , unionsFour       = E4_2 "foo"
+        , unionsFive       = E5_4 $ Foo { fooStuff = "foo stuff" }
         }
       unionsExampleB = Unions
-        { unionsScalars = Right 37
-        , unionsNullable = Just 42
-        , unionsRecords = Right $ Bar { barStuff = "stuff"
+        { unionsScalars    = Right 37
+        , unionsNullable   = Just 42
+        , unionsRecords    = Right $ Bar { barStuff = "stuff"
                                       , barThings = Foo "things"
                                       }
         , unionsSameFields = Right $ NotFoo { notFooStuff = "not foo stuff" }
+        , unionsThree      = E3_3 37
+        , unionsFour       = E4_4 $ Foo { fooStuff = "foo stuff" }
+        , unionsFive       = E5_5 $ NotFoo { notFooStuff = "not foo stuff" }
         }
   it "should roundtrip (unions)" $ do
     forM_ [unionsExampleA, unionsExampleB] $ \ msg ->

--- a/test/data/unions-object-a.json
+++ b/test/data/unions-object-a.json
@@ -12,5 +12,10 @@
     "haskell.avro.example.Foo": {
       "stuff": "foo stuff"
     }
+  },
+  "three": { "int": 37 },
+  "four": { "string": "foo" },
+  "five": {
+    "haskell.avro.example.Foo": { "stuff": "foo stuff" }
   }
 }

--- a/test/data/unions-object-b.json
+++ b/test/data/unions-object-b.json
@@ -17,5 +17,12 @@
     "haskell.avro.example.NotFoo": {
       "stuff": "not foo stuff"
     }
+  },
+  "three": { "long": 37 },
+  "four": {
+    "haskell.avro.example.Foo": { "stuff" : "foo stuff" }
+  },
+  "five": {
+    "haskell.avro.example.NotFoo": { "stuff": "not foo stuff" }
   }
 }

--- a/test/data/unions.avsc
+++ b/test/data/unions.avsc
@@ -43,6 +43,9 @@
           ]
         }
       ]
-    }
+    },
+    { "name" : "three", "type" : ["int", "string", "long"] },
+    { "name" : "four", "type" : ["int", "string", "long", "Foo"] },
+    { "name" : "five", "type" : ["int", "string", "long", "Foo", "NotFoo"] }
   ]
 }


### PR DESCRIPTION
The last PR accidentally reverted the union logic. This PR returns that logic and adds three, four and five element unions to the test suite (in `THUnionSpec.hs` and `JSONSpec.hs`). Changes to the union logic should now get caught by the test suite.