### PR TITLE
Changed Schema toJSON logic to use namespace inference where possible.

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.28.2.
+cabal-version: >= 1.10
+
+-- This file has been generated from package.yaml by hpack version 0.29.7.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: df77e046e65bd987123d33da69b0e843f877bd76dea4406b0e1fd22d9fd5a8f8
+-- hash: 30e0babcd4c8a6a23201f461f21db13c1a6f0eac1b6e5245ad28b9c1eb71318b
 
 name:           avro
 version:        0.3.5.1
@@ -16,7 +18,6 @@ maintainer:     Alexey Raga <alexey.raga@gmail.com>
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
 extra-source-files:
     ChangeLog.md
     test/data/deconflict/reader.avsc
@@ -26,6 +27,7 @@ extra-source-files:
     test/data/karma.avsc
     test/data/logical.avsc
     test/data/maybe.avsc
+    test/data/namespace-inference.json
     test/data/record.avsc
     test/data/reused.avsc
     test/data/small.avsc
@@ -132,6 +134,7 @@ test-suite test
       Avro.DefaultsSpec
       Avro.EncodeRawSpec
       Avro.JSONSpec
+      Avro.NamespaceSpec
       Avro.NormSchemaSpec
       Avro.THEncodeContainerSpec
       Avro.THEnumSpec

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ extra-source-files:
 - test/data/unions-object-b.json
 - test/data/deconflict/writer.avsc
 - test/data/deconflict/reader.avsc
+- test/data/namespace-inference.json
 dependencies:
 - aeson
 - array

--- a/test/Avro/NamespaceSpec.hs
+++ b/test/Avro/NamespaceSpec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Avro.NamespaceSpec where
+
+import           Control.Monad        (forM_)
+
+import qualified Data.Aeson           as Aeson
+import qualified Data.ByteString.Lazy as LBS
+
+import           System.Directory     (doesFileExist, getCurrentDirectory)
+import           System.Environment   (setEnv)
+
+import           Test.Hspec
+
+import           Paths_avro
+
+import           Data.Avro.Schema
+
+spec :: Spec
+spec = describe "NamespaceSpec.hs: namespace inference in Avro schemas" $ do
+  schemas <- runIO $ getFileName "test/data/namespace-inference.json" >>= LBS.readFile
+  let parsedSchemas :: [Schema]
+      Just parsedSchemas = Aeson.decode schemas
+  it "should infer namespaces correctly" $ do
+    forM_ parsedSchemas (`shouldBe` expected)
+  it "should generate JSON with namespaces inferred" $ do
+    -- the first schema in namespace-ifnerence.json is in the exact
+    -- format we expect to serialize Schema values
+    let expectedJSONSchema :: Aeson.Value
+        Just expectedJSONSchema = head <$> Aeson.decode schemas
+    Aeson.toJSON expected `shouldBe` expectedJSONSchema
+
+expected :: Schema
+expected = Record
+  { name    = "com.example.Foo"
+  , aliases = ["com.example.FooBar", "com.example.not.Bar"]
+  , doc     = Just "An example schema to test namespace handling."
+  , order   = Just Ascending
+  , fields  = [field "bar" bar, field "baz" $ NamedType "com.example.baz.Baz"]
+  }
+  where field name schema = Field name [] Nothing (Just Ascending) schema Nothing
+
+        bar = Record
+          { name    = "com.example.Bar"
+          , aliases = ["com.example.Bar2", "com.example.not.Foo"]
+          , doc     = Nothing
+          , order   = Just Ascending
+          , fields  = [ field "baz" baz
+                      , field "bazzy" $ NamedType "com.example.Bazzy"
+                      ]
+          }
+
+        baz = Record
+          { name    = "com.example.baz.Baz"
+          , aliases = ["com.example.Bazzy"]
+          , doc     = Nothing
+          , order   = Just Ascending
+          , fields  = [ field "baz"   $ NamedType "com.example.baz.Baz"
+                      , field "bazzy" $ NamedType "com.example.Bazzy"
+                      ]
+          }
+
+getFileName :: FilePath -> IO FilePath
+getFileName p = do
+  path <- getDataFileName p
+  isOk <- doesFileExist path
+  pure $ if isOk then path else p

--- a/test/data/namespace-inference.json
+++ b/test/data/namespace-inference.json
@@ -1,0 +1,154 @@
+[
+  {
+    "type" : "record",
+    "name" : "com.example.Foo",
+    "aliases" : ["FooBar", "com.example.not.Bar"],
+    "doc" : "An example schema to test namespace handling.",
+    "order" : "ascending",
+    "fields" : [
+      {
+        "name" : "bar",
+        "aliases" : [],
+        "order" : "ascending",
+        "type" : {
+          "type" : "record",
+          "name" : "Bar",
+          "order" : "ascending",
+          "aliases" : ["Bar2", "com.example.not.Foo"],
+          "fields" : [
+            {
+              "name" : "baz",
+              "aliases" : [],
+              "order" : "ascending",
+              "type" : {
+                "type" : "record",
+                "order" : "ascending",
+                "name" : "com.example.baz.Baz",
+                "aliases" : ["com.example.Bazzy"],
+                "fields" : [
+                  {
+                    "name"    : "baz",
+                    "type"    : "Baz",
+                    "aliases" : [],
+                    "order"   : "ascending"
+                  },
+                  {
+                    "name"    : "bazzy",
+                    "type"    : "com.example.Bazzy",
+                    "aliases" : [],
+                    "order"   : "ascending"
+                  }
+                ]
+              }
+            },
+            {
+              "name"    : "bazzy",
+              "type"    : "Bazzy",
+              "aliases" : [],
+              "order"   : "ascending"
+            }
+          ]
+        }
+      },
+      {
+        "name"    : "baz",
+        "type"    : "com.example.baz.Baz",
+        "aliases" : [],
+        "order"   : "ascending"
+      }
+    ]
+  },
+  {
+    "type" : "record",
+    "name" : "Foo",
+    "namespace" : "com.example",
+    "aliases" : ["FooBar", "com.example.not.Bar"],
+    "doc" : "An example schema to test namespace handling.",
+    "fields" : [
+      {
+        "name" : "bar",
+        "namespace" : "com.example",
+        "type" : {
+          "type" : "record",
+          "name" : "Bar",
+          "aliases" : ["Bar2", "com.example.not.Foo"],
+          "fields" : [
+            {
+              "name" : "baz",
+              "type" : {
+                "type" : "record",
+                "name" : "Baz",
+                "namespace" : "com.example.baz",
+                "aliases" : ["com.example.Bazzy"],
+                "fields" : [
+                  {
+                    "name" : "baz",
+                    "type" : "Baz"
+                  },
+                  {
+                    "name" : "bazzy",
+                    "type" : "com.example.Bazzy"
+                  }
+                ]
+              }
+            },
+            {
+              "name" : "bazzy",
+              "type" : "Bazzy"
+            }
+          ]
+        }
+      },
+      {
+        "name" : "baz",
+        "type" : "com.example.baz.Baz"
+      }
+    ]
+  },
+  {
+    "type" : "record",
+    "name" : "com.example.Foo",
+    "namespace" : "should.be.ignored",
+    "aliases" : ["FooBar", "com.example.not.Bar"],
+    "doc" : "An example schema to test namespace handling.",
+    "fields" : [
+      {
+        "name" : "bar",
+        "type" : {
+          "type" : "record",
+          "name" : "Bar",
+          "aliases" : ["Bar2", "com.example.not.Foo"],
+          "fields" : [
+            {
+              "name" : "baz",
+              "type" : {
+                "type" : "record",
+                "name" : "com.example.baz.Baz",
+                "namespace" : "should.be.ignored",
+                "aliases" : ["com.example.Bazzy"],
+                "fields" : [
+                  {
+                    "name" : "baz",
+                    "type" : "Baz"
+                  },
+                  {
+                    "name" : "bazzy",
+                    "type" : "com.example.Bazzy"
+                  }
+                ]
+              }
+            },
+            {
+              "name" : "bazzy",
+              "type" : "Bazzy"
+            }
+          ]
+        }
+      },
+      {
+        "name" : "baz",
+        "type" : "com.example.baz.Baz"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Now the JSON generated for a schema only uses namespaces when necessary to disambiguate, using only the base name if the namespace could be inferred.

I also added a test which checks both this logic and namespace inference in general.