### PR TITLE
Support using one schema to resolve references in another

### DIFF
--- a/test/Avro/SchemaSpec.hs
+++ b/test/Avro/SchemaSpec.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+module Avro.SchemaSpec
+where
+
+import           Data.Avro
+import           Data.Avro.Deriving (makeSchema)
+import           Data.Avro.Schema   (overlay, matches)
+
+import           Test.Hspec
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+spec :: Spec
+spec = describe "Avro.SchemaSpec" $ do
+  describe "overlay" $
+    it "should support merging multiple schemas" $ do
+      let expected   = $(makeSchema "test/data/overlay/expectation.avsc")
+          consumer   = $(makeSchema "test/data/overlay/composite.avsc")
+          primitives = $(makeSchema "test/data/overlay/primitives.avsc")
+
+      consumer `overlay` primitives `shouldSatisfy` matches expected

--- a/test/data/overlay/composite.avsc
+++ b/test/data/overlay/composite.avsc
@@ -1,0 +1,39 @@
+{
+  "type": "record",
+  "name": "composite",
+  "fields": [
+    {
+      "name": "foo-bar-field",
+      "type": "avro.test.data.overlay.primitive.foo-bar"
+    },
+    {
+      "name": "foo-enum-field",
+      "type": "avro.test.data.overlay.primitive.foo-enumeration"
+    },
+    {
+      "name": "foo-fixed-field",
+      "type": "avro.test.data.overlay.primitive.foo-fixed"
+    },
+    {
+      "name": "foo-union-1",
+      "type": "avro.test.data.overlay.primitive.foo-union-1"
+    },
+    {
+      "name": "foo-bar-array",
+      "type": "array",
+      "items": "avro.test.data.overlay.primitive.foo-bar"
+    },
+    {
+      "name": "foo-bar-map",
+      "type": "map",
+      "values": "avro.test.data.overlay.primitive.foo-bar"
+    },
+    {
+      "name": "foo-bar-int-union",
+      "type": [
+        "int",
+        "avro.test.data.overlay.primitive.foo-bar"
+      ]
+    }
+  ]
+}

--- a/test/data/overlay/expectation.avsc
+++ b/test/data/overlay/expectation.avsc
@@ -1,0 +1,91 @@
+{
+  "type": "record",
+  "name": "composite",
+  "fields": [
+    {
+      "name": "foo-bar-field",
+      "type": {
+        "type": "record",
+        "name": "avro.test.data.overlay.primitive.foo-bar",
+        "fields": [
+          {
+            "name": "field2.1",
+            "type": "int"
+          }
+        ]
+      }
+    },
+    {
+      "name": "foo-enum-field",
+      "type": {
+        "type": "enum",
+        "name": "avro.test.data.overlay.primitive.foo-enumeration",
+        "symbols": ["fe1", "fe2"]
+      }
+    },
+    {
+      "name": "foo-fixed-field",
+      "type": {
+        "type": "fixed",
+        "name": "avro.test.data.overlay.primitive.foo-fixed",
+        "size": 2
+      }
+    },
+    {
+      "name": "foo-union-1",
+      "type": {
+        "type": "record",
+        "name": "avro.test.data.overlay.primitive.foo-union-1",
+        "fields": [ { "name" : "foo-union-1.1", "type": "int"} ]
+      }
+    },
+    {
+      "name": "foo-bar-array",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "avro.test.data.overlay.primitive.foo-bar",
+          "fields": [
+            {
+              "name": "field2.1",
+              "type": "int"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "foo-bar-map",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "record",
+          "name": "avro.test.data.overlay.primitive.foo-bar",
+          "fields": [
+            {
+              "name": "field2.1",
+              "type": "int"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "foo-bar-int-union",
+      "type": [
+        "int",
+        {
+          "type": "record",
+          "name": "avro.test.data.overlay.primitive.foo-bar",
+          "fields": [
+            {
+              "name": "field2.1",
+              "type": "int"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/data/overlay/primitives.avsc
+++ b/test/data/overlay/primitives.avsc
@@ -1,0 +1,51 @@
+{
+  "type": "record",
+  "name": "foo",
+  "namespace": "avro.test.data.overlay.primitive",
+  "fields": [
+    {
+      "name": "field1",
+      "type": "int"
+    },
+    {
+      "name": "field2",
+      "type": {
+        "type": "record",
+        "name": "foo-bar",
+        "fields": [
+          {
+            "name": "field2.1",
+            "type": "int"
+          }
+        ]
+      }
+    },
+    {
+      "name": "field3",
+      "type": {
+        "type": "enum",
+        "name": "foo-enumeration",
+        "symbols": ["fe1", "fe2"]
+      }
+    },
+    {
+      "name": "field4",
+      "type": {
+        "type": "fixed",
+        "name": "foo-fixed",
+        "size": 2
+      }
+    },
+    {
+      "name": "field5",
+      "type": [
+        "string",
+        {
+          "type": "record",
+          "name": "foo-union-1",
+          "fields": [ { "name" : "foo-union-1.1", "type": "int"} ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I have schemas defined in multiple `.avsc` files that I've been pulling in using `makeSchema`. There are several primitives, and one composite schema. Problem is, the composite schema has unresolved references because each `makeSchema` occurs in isolation.

With this change I can now use those schemas to fill in the references in my composite schema.