### PR TITLE
Process invalid UTF-8 without crashing

### DIFF
--- a/src/Data/Avro/Decode/Get.hs
+++ b/src/Data/Avro/Decode/Get.hs
@@ -147,7 +147,11 @@ getBytes =
     G.getByteString (fromIntegral w)
 
 getString :: Get Text
-getString = Text.decodeUtf8 <$> getBytes
+getString = do
+  bytes <- getBytes
+  case Text.decodeUtf8' bytes of
+    Left unicodeExc -> fail (show unicodeExc)
+    Right text -> return text
 
 -- a la Java:
 --  Bit 31 (the bit that is selected by the mask 0x80000000) represents the

--- a/test/Avro/Codec/TextSpec.hs
+++ b/test/Avro/Codec/TextSpec.hs
@@ -6,6 +6,7 @@ module Avro.Codec.TextSpec (spec) where
 import           Data.Avro
 import           Data.Avro.Schema
 import           Data.Text
+import qualified Data.ByteString.Lazy as BSL
 import           Data.Tagged
 import           Test.Hspec
 import qualified Data.Avro.Types      as AT
@@ -46,3 +47,10 @@ spec = describe "Avro.Codec.TextSpec" $ do
   it "Can decode encoded Text values" $ do
     Q.property $ \(t :: String) ->
       decode (encode (OnlyText (pack t))) == Success (OnlyText (pack t))
+
+  it "Can process corrupted Text values without crashing" $ do
+    Q.property $ \bytes ->
+      let result                   = decode (BSL.pack bytes) :: Result Text
+          isSafeResult (Success _) = True
+          isSafeResult (Error _)   = True
+      in result `shouldSatisfy` isSafeResult


### PR DESCRIPTION
On encountering invalid UTF8 values `Text.decodeUtf8` will throw an exception that can't be caught from pure code. `Result` doesn't have the right type to make a `MonadCatch`, so by process of elimination we're using `Text.decodeUtf8'` to get an `Either UnicodeException Text` we can turn into a `Result`.