### PR TITLE
Fixed Data.Avro.Schema.extractBindings.

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -23,6 +23,7 @@ extra-source-files:
     test/data/deconflict/writer.avsc
     test/data/enums-object.json
     test/data/enums.avsc
+    test/data/internal-bindings.avsc
     test/data/karma.avsc
     test/data/logical.avsc
     test/data/maybe.avsc

--- a/test/Avro/SchemaSpec.hs
+++ b/test/Avro/SchemaSpec.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE OverloadedLists     #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 module Avro.SchemaSpec
 where
 
+import qualified Data.HashMap.Lazy  as HashMap
+import qualified Data.HashSet       as HashSet
+
 import           Data.Avro
 import           Data.Avro.Deriving (makeSchema)
-import           Data.Avro.Schema   (overlay, matches)
+import           Data.Avro.Schema   (extractBindings, matches, overlay)
 
 import           Test.Hspec
 
@@ -15,6 +19,25 @@ import           Test.Hspec
 
 spec :: Spec
 spec = describe "Avro.SchemaSpec" $ do
+  describe "extractBindings" $
+    it "should extract bindings for all internal types" $ do
+    let schema = $(makeSchema "test/data/internal-bindings.avsc")
+        bindings = extractBindings schema
+        expected =
+          [ "InternalBindings"
+          , "InField"
+          , "NestedInField"
+          , "AliasNestedInField"
+          , "NestedEnum"
+          , "NestedFixed"
+          , "InArray"
+          , "NestedInArray"
+          , "InMap"
+          , "NestedInMap"
+          , "InUnionA"
+          , "InUnionB"
+          ]
+    HashSet.fromMap (() <$ bindings) == expected
   describe "overlay" $
     it "should support merging multiple schemas" $ do
       let expected   = $(makeSchema "test/data/overlay/expectation.avsc")

--- a/test/data/internal-bindings.avsc
+++ b/test/data/internal-bindings.avsc
@@ -1,0 +1,105 @@
+{
+  "name" : "InternalBindings",
+  "type" : "record",
+  "doc" : "A test record that includes subdefinitions nested in different ways.",
+  "fields" : [
+    {
+      "name" : "inField",
+      "doc" : "A record definition nested in a field of a record.",
+      "type" : {
+        "name" : "InField",
+        "type" : "record",
+        "fields" : [
+          {
+            "name" : "nestedInField",
+            "doc" : "A record definition nested in two other records.",
+            "type" : {
+              "name" : "NestedInField",
+              "type" : "record",
+              "aliases" : ["AliasNestedInField"],
+              "fields" : []
+            }
+          },
+          {
+            "name" : "nestedEnum",
+            "doc" : "An enum definition nested in a nested record.",
+            "type" : {
+              "type" : "enum",
+              "name" : "NestedEnum",
+              "symbols" : ["Foo", "Bar"]
+            }
+          },
+          {
+            "name" : "nestedFixed",
+            "doc" : "A fixed definition nested in a nested record.",
+            "type" : {
+              "type" : "fixed",
+              "size" : 42,
+              "name" : "NestedFixed"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name" : "inArray",
+      "doc" : "A record definition nested in an array type.",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "name" : "InArray",
+          "type" : "record",
+          "fields" : [
+            {
+              "name" : "nestedInArray",
+              "doc" : "A record definition nested inside a record defined in an array.",
+              "type" : {
+                "name" : "NestedInArray",
+                "type" : "record",
+                "fields" : []
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name" : "inMap",
+      "doc" : "A record definition nested in a map type.",
+      "type" : {
+        "type" : "map",
+        "values" : {
+          "name" : "InMap",
+          "type" : "record",
+          "fields" : [
+            {
+              "name" : "nestedInMap",
+              "doc" : "A record definition nested inside a record defined in a map.",
+              "type" : {
+                "name" : "NestedInMap",
+                "type" : "record",
+                "fields" : []
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name" : "inUnion",
+      "doc" : "Record definitions nested in a union.",
+      "type" : [
+        {
+          "name" : "InUnionA",
+          "type" : "record",
+          "fields" : []
+        },
+        {
+          "name" : "InUnionB",
+          "type" : "record",
+          "fields" : []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The old implementation had some odd bugs with nested type definitions, including missing types defined inside arrays and maps. This PR has a new implementation of extractBindings that fixes all the problems as well as a test case which covers a bunch of edge cases for extracting types from a schema.