### PR TITLE
Use globs in package.yaml to keep extra-source-files up to date

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 686c91bf89cf070fdd57de52066edac6394a61472b3927e5c8fab77a5c009ba1
+-- hash: 70b4468aa133c8dc67598676745852fa445ca9ee5a79cf745b27997c6b7fbffd
 
 name:           avro
 version:        0.3.6.1
@@ -21,18 +21,17 @@ extra-source-files:
     ChangeLog.md
     test/data/deconflict/reader.avsc
     test/data/deconflict/writer.avsc
-    test/data/enums-object.json
     test/data/enums.avsc
     test/data/internal-bindings.avsc
     test/data/karma.avsc
     test/data/logical.avsc
     test/data/maybe.avsc
-    test/data/namespace-inference.json
+    test/data/overlay/composite.avsc
+    test/data/overlay/expectation.avsc
+    test/data/overlay/primitives.avsc
     test/data/record.avsc
     test/data/reused.avsc
     test/data/small.avsc
-    test/data/unions-object-a.json
-    test/data/unions-object-b.json
     test/data/unions.avsc
 
 source-repository head

--- a/package.yaml
+++ b/package.yaml
@@ -9,21 +9,8 @@ license: BSD3
 github: GaloisInc/avro
 extra-source-files:
 - ChangeLog.md
-- test/data/reused.avsc
-- test/data/small.avsc
-- test/data/enums.avsc
-- test/data/maybe.avsc
-- test/data/unions.avsc
-- test/data/karma.avsc
-- test/data/record.avsc
-- test/data/logical.avsc
-- test/data/enums-object.json
-- test/data/unions-object-a.json
-- test/data/unions-object-b.json
-- test/data/deconflict/writer.avsc
-- test/data/deconflict/reader.avsc
-- test/data/namespace-inference.json
-- test/data/internal-bindings.avsc
+- test/data/*.avsc
+- test/data/*/*.avsc
 dependencies:
 - aeson
 - array


### PR DESCRIPTION
Some of the .avsc files used in tests were left out of the `extra-source-files` field, so they weren't copied to Hackage on the last release. (`avro-0.3.6.1` tests on Hackage fail)

This change uses globs to grab all .avsc files when the cabal file is generated by hpack, so future `cabal sdist` won't leave them out. This gets tests working again on my system.

This is tricky to catch in CI, since the bug is only introduced upon hackage upload :)

N.B. I didn't bump the version bounds