### PR TITLE
Add .json test fixtures to cabal sdist

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Revision history for avro
 
-## 0.4.1.0  -- 2018-11-07
+## HEAD  -- 2018-11-07
 
 * Fixed an omitted data fixture from the cabal sdist
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for avro
 
+## 0.4.1.0  -- 2018-11-07
+
+* Fixed an omitted data fixture from the cabal sdist
+
 ## 0.1.0.0  -- YYYY-mm-dd
 
 * First version. Released on an unsuspecting world.

--- a/avro.cabal
+++ b/avro.cabal
@@ -2,10 +2,10 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fcff216c51da7f4f507714e81688ee3d9c149e101ffbe1b7051f4559eb2feebb
+-- hash: bfec925895943164224c08cad0c74436c45b1a75efd82d149d9643542ed7289d
 
 name:           avro
-version:        0.4.0.0
+version:        0.4.1.0
 synopsis:       Avro serialization support for Haskell
 description:    Avro serialization and deserialization support for Haskell
 category:       Data
@@ -21,17 +21,21 @@ extra-source-files:
     ChangeLog.md
     test/data/deconflict/reader.avsc
     test/data/deconflict/writer.avsc
+    test/data/enums-object.json
     test/data/enums.avsc
     test/data/internal-bindings.avsc
     test/data/karma.avsc
     test/data/logical.avsc
     test/data/maybe.avsc
+    test/data/namespace-inference.json
     test/data/overlay/composite.avsc
     test/data/overlay/expectation.avsc
     test/data/overlay/primitives.avsc
     test/data/record.avsc
     test/data/reused.avsc
     test/data/small.avsc
+    test/data/unions-object-a.json
+    test/data/unions-object-b.json
     test/data/unions.avsc
 
 source-repository head

--- a/avro.cabal
+++ b/avro.cabal
@@ -5,7 +5,7 @@
 -- hash: bfec925895943164224c08cad0c74436c45b1a75efd82d149d9643542ed7289d
 
 name:           avro
-version:        0.4.1.0
+version:        0.4.0.0
 synopsis:       Avro serialization support for Haskell
 description:    Avro serialization and deserialization support for Haskell
 category:       Data

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: avro
-version: '0.4.0.0'
+version: '0.4.1.0'
 synopsis: Avro serialization support for Haskell
 description: Avro serialization and deserialization support for Haskell
 category: Data
@@ -10,6 +10,7 @@ github: GaloisInc/avro
 extra-source-files:
 - ChangeLog.md
 - test/data/*.avsc
+- test/data/*.json
 - test/data/*/*.avsc
 dependencies:
 - aeson


### PR DESCRIPTION
Sorry @AlexeyRaga, my last PR didn't include test fixtures with `.json` extension. Not sure how I missed that in my testing.