### PR TITLE
From lazy avro

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3f614ae94c186bff5ad6b6cba2954ed79e902693d3df1f20863908697f581092
+-- hash: 4a4c0411085a3834287f648dd8976f15d72294196b6aeef1509ba08dd67e6fbd
 
 name:           avro
 version:        0.4.0.0
@@ -91,6 +91,7 @@ library
     , array
     , base >=4.8 && <5.0
     , base16-bytestring
+    , bifunctors
     , binary
     , bytestring
     , containers
@@ -161,6 +162,7 @@ test-suite test
     , avro
     , base >=4.6 && <5
     , base16-bytestring
+    , bifunctors
     , binary
     , bytestring
     , containers

--- a/avro.cabal
+++ b/avro.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bfec925895943164224c08cad0c74436c45b1a75efd82d149d9643542ed7289d
+-- hash: 3f614ae94c186bff5ad6b6cba2954ed79e902693d3df1f20863908697f581092
 
 name:           avro
 version:        0.4.0.0
@@ -60,6 +60,7 @@ library
       Data.Avro.Decode.Lazy
       Data.Avro.Decode.Lazy.Convert
       Data.Avro.Decode.Lazy.Deconflict
+      Data.Avro.Decode.Lazy.FromLazyAvro
       Data.Avro.Decode.Lazy.LazyValue
       Data.Avro.Decode.Strict
       Data.Avro.Decode.Strict.Internal

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: avro
-version: '0.4.1.0'
+version: '0.4.0.0'
 synopsis: Avro serialization support for Haskell
 description: Avro serialization and deserialization support for Haskell
 category: Data
@@ -16,6 +16,7 @@ dependencies:
 - aeson
 - array
 - base16-bytestring
+- bifunctors
 - binary
 - bytestring
 - containers

--- a/src/Data/Avro/Decode.hs
+++ b/src/Data/Avro/Decode.hs
@@ -14,38 +14,38 @@ module Data.Avro.Decode
   , GetAvro(..)
   ) where
 
-import qualified Codec.Compression.Zlib     as Z
-import           Control.Monad              (replicateM, when)
-import qualified Data.Aeson                 as A
-import qualified Data.Array                 as Array
-import           Data.Binary.Get            (Get, runGetOrFail)
-import qualified Data.Binary.Get            as G
-import           Data.Binary.IEEE754        as IEEE
+import qualified Codec.Compression.Zlib           as Z
+import           Control.Monad                    (replicateM, when)
+import qualified Data.Aeson                       as A
+import qualified Data.Array                       as Array
+import           Data.Binary.Get                  (Get, runGetOrFail)
+import qualified Data.Binary.Get                  as G
+import           Data.Binary.IEEE754              as IEEE
 import           Data.Bits
-import           Data.ByteString            (ByteString)
-import qualified Data.ByteString.Lazy       as BL
-import qualified Data.ByteString.Lazy.Char8 as BC
-import qualified Data.HashMap.Strict        as HashMap
+import           Data.ByteString                  (ByteString)
+import qualified Data.ByteString.Lazy             as BL
+import qualified Data.ByteString.Lazy.Char8       as BC
+import qualified Data.HashMap.Strict              as HashMap
 import           Data.Int
-import           Data.List                  (foldl')
-import qualified Data.List.NonEmpty         as NE
-import qualified Data.Map                   as Map
+import           Data.List                        (foldl')
+import qualified Data.List.NonEmpty               as NE
+import qualified Data.Map                         as Map
 import           Data.Maybe
-import           Data.Monoid                ((<>))
-import qualified Data.Set                   as Set
-import           Data.Text                  (Text)
-import qualified Data.Text                  as Text
-import qualified Data.Text.Encoding         as Text
-import qualified Data.Vector                as V
-import           Prelude                    as P
+import           Data.Monoid                      ((<>))
+import qualified Data.Set                         as Set
+import           Data.Text                        (Text)
+import qualified Data.Text                        as Text
+import qualified Data.Text.Encoding               as Text
+import qualified Data.Vector                      as V
+import           Prelude                          as P
 
 import           Data.Avro.Decode.Get
 import           Data.Avro.DecodeRaw
-import           Data.Avro.Schema     as S
-import qualified Data.Avro.Types      as T
+import           Data.Avro.Schema                 as S
+import qualified Data.Avro.Types                  as T
 import           Data.Avro.Zag
 
-import Data.Avro.Decode.Strict.Internal
+import           Data.Avro.Decode.Strict.Internal
 
 -- |Decode bytes into a 'Value' as described by Schema.
 decodeAvro :: Schema -> BL.ByteString -> Either String (T.Value Type)

--- a/src/Data/Avro/Decode/Lazy.hs
+++ b/src/Data/Avro/Decode/Lazy.hs
@@ -23,51 +23,53 @@ module Data.Avro.Decode.Lazy
   , getContainerValuesBytes'
   , getAvroOf
   , GetAvro(..)
+  , FromLazyAvro(..)
+  , (.~:)
+  , T.LazyValue(..)
+  , badValue
   ) where
 
-import qualified Codec.Compression.Zlib             as Z
-import           Control.Monad                      (foldM, replicateM, when)
-import qualified Data.Aeson                         as A
-import qualified Data.Array                         as Array
-import           Data.Binary.Get                    (Get, runGetOrFail)
-import qualified Data.Binary.Get                    as G
-import           Data.Binary.IEEE754                as IEEE
+import qualified Codec.Compression.Zlib     as Z
+import           Control.Monad              (foldM, replicateM, when)
+import qualified Data.Aeson                 as A
+import qualified Data.Array                 as Array
+import           Data.Binary.Get            (Get, runGetOrFail)
+import qualified Data.Binary.Get            as G
+import           Data.Binary.IEEE754        as IEEE
 import           Data.Bits
-import           Data.ByteString                    (ByteString)
-import qualified Data.ByteString.Lazy               as BL
-import qualified Data.ByteString.Lazy.Char8         as BL
-import           Data.Either                        (isRight)
-import qualified Data.HashMap.Strict                as HashMap
+import           Data.ByteString            (ByteString)
+import qualified Data.ByteString.Lazy       as BL
+import qualified Data.ByteString.Lazy.Char8 as BL
+import           Data.Either                (isRight)
+import qualified Data.HashMap.Strict        as HashMap
 import           Data.Int
-import           Data.List                          (foldl', unfoldr)
-import qualified Data.List.NonEmpty                 as NE
-import qualified Data.Map                           as Map
+import           Data.List                  (foldl', unfoldr)
+import qualified Data.List.NonEmpty         as NE
+import qualified Data.Map                   as Map
 import           Data.Maybe
-import           Data.Monoid                        ((<>))
-import qualified Data.Set                           as Set
-import           Data.Tagged                        (Tagged, untag)
-import           Data.Text                          (Text)
-import qualified Data.Text                          as Text
-import qualified Data.Text.Encoding                 as Text
-import qualified Data.Vector                        as V
-import           Prelude                            as P
+import           Data.Monoid                ((<>))
+import qualified Data.Set                   as Set
+import           Data.Tagged                (Tagged, untag)
+import           Data.Text                  (Text)
+import qualified Data.Text                  as Text
+import qualified Data.Text.Encoding         as Text
+import qualified Data.Vector                as V
+import           Prelude                    as P
 
-import qualified Data.Avro.Decode.Lazy.LazyValue    as T
+import qualified Data.Avro.Decode.Lazy.LazyValue as T
 import           Data.Avro.DecodeRaw
-import           Data.Avro.HasAvroSchema            (schema)
-import           Data.Avro.Schema                   as S
-import qualified Data.Avro.Types                    as TypesStrict
+import           Data.Avro.HasAvroSchema         (schema)
+import           Data.Avro.Schema                as S
+import qualified Data.Avro.Types                 as TypesStrict
 import           Data.Avro.Zag
 
-import qualified Data.Avro.Decode.Strict.Internal   as DecodeStrict
+import qualified Data.Avro.Decode.Strict.Internal as DecodeStrict
 
-import           Data.Avro.Decode.Get
-import           Data.Avro.Decode.Lazy.Convert      (toStrictValue)
-import           Data.Avro.Decode.Lazy.Deconflict   as C
-import           Data.Avro.Decode.Lazy.FromLazyAvro
-import           Data.Avro.FromAvro
-
-import           Debug.Trace
+import Data.Avro.Decode.Get
+import Data.Avro.Decode.Lazy.Convert      (toStrictValue)
+import Data.Avro.Decode.Lazy.Deconflict   as C
+import Data.Avro.Decode.Lazy.FromLazyAvro
+import Data.Avro.FromAvro
 
 -- | Decodes the container as a lazy list of values of the requested type.
 --
@@ -201,7 +203,7 @@ getNextBlock sync decompress bs =
     checkMarker sync bs =
       case BL.splitAt nrSyncBytes bs of
         (marker, _) | marker /= sync -> Left "Invalid marker, does not match sync bytes."
-        (_, rest)   -> Right rest
+        (_, rest)                    -> Right rest
 
 getContainerValuesWith :: (Schema -> BL.ByteString -> (BL.ByteString, T.LazyValue Type))
                  -> BL.ByteString

--- a/src/Data/Avro/Decode/Lazy/FromLazyAvro.hs
+++ b/src/Data/Avro/Decode/Lazy/FromLazyAvro.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Data.Avro.Decode.Lazy.FromLazyAvro
+
+where
+
+import           Control.Arrow                   (first)
+import           Data.Avro.Decode.Lazy.LazyValue as T
+import qualified Data.Avro.Encode                as E
+import           Data.Avro.HasAvroSchema
+import           Data.Avro.Schema                as S
+import qualified Data.ByteString                 as B
+import           Data.ByteString.Lazy            (ByteString)
+import qualified Data.ByteString.Lazy            as BL
+import           Data.Foldable                   (toList)
+import qualified Data.HashMap.Strict             as HashMap
+import           Data.Int
+import           Data.List.NonEmpty              (NonEmpty (..))
+import qualified Data.Map                        as Map
+import           Data.Monoid                     ((<>))
+import           Data.Tagged
+import           Data.Text                       (Text)
+import qualified Data.Text                       as Text
+import qualified Data.Text.Lazy                  as TL
+import qualified Data.Vector                     as V
+import qualified Data.Vector.Unboxed             as U
+import           Data.Word
+
+class HasAvroSchema a => FromLazyAvro a where
+  fromLazyAvro :: LazyValue Type -> Result a
+
+(.~:) :: FromLazyAvro a => HashMap.HashMap Text (LazyValue Type) -> Text -> Result a
+(.~:) obj key =
+  case HashMap.lookup key obj of
+    Nothing -> fail $ "Requested field not available: " <> show key
+    Just v  -> fromLazyAvro v
+
+instance (FromLazyAvro a, FromLazyAvro b) => FromLazyAvro (Either a b) where
+  fromLazyAvro e@(T.Union _ branch x)
+    | S.matches branch schemaA = Left  <$> fromLazyAvro x
+    | S.matches branch schemaB = Right <$> fromLazyAvro x
+    | otherwise              = badLazyValue e "either"
+    where Tagged schemaA = schema :: Tagged a Type
+          Tagged schemaB = schema :: Tagged b Type
+  fromLazyAvro x = badLazyValue x "either"
+instance FromLazyAvro Bool where
+  fromLazyAvro (T.Boolean b) = pure b
+  fromLazyAvro v             = badLazyValue v "Bool"
+instance FromLazyAvro B.ByteString where
+  fromLazyAvro (T.Bytes b) = pure b
+  fromLazyAvro v           = badLazyValue v "ByteString"
+instance FromLazyAvro BL.ByteString where
+  fromLazyAvro (T.Bytes b) = pure (BL.fromStrict b)
+  fromLazyAvro v           = badLazyValue v "Lazy ByteString"
+instance FromLazyAvro Int where
+  fromLazyAvro (T.Int i) | (fromIntegral i :: Integer) < fromIntegral (maxBound :: Int)
+                      = pure (fromIntegral i)
+  fromLazyAvro (T.Long i) | (fromIntegral i :: Integer) < fromIntegral (maxBound :: Int)
+                      = pure (fromIntegral i)
+  fromLazyAvro v          = badLazyValue v "Int"
+instance FromLazyAvro Int32 where
+  fromLazyAvro (T.Int i) = pure (fromIntegral i)
+  fromLazyAvro v         = badLazyValue v "Int32"
+instance FromLazyAvro Int64 where
+  fromLazyAvro (T.Long i) = pure i
+  fromLazyAvro (T.Int i)  = pure (fromIntegral i)
+  fromLazyAvro v          = badLazyValue v "Int64"
+instance FromLazyAvro Double where
+  fromLazyAvro (T.Double d) = pure d
+  fromLazyAvro v            = badLazyValue v "Double"
+
+instance FromLazyAvro Float where
+  fromLazyAvro (T.Float f) = pure f
+  fromLazyAvro v           = badLazyValue v "Float"
+
+instance FromLazyAvro a => FromLazyAvro (Maybe a) where
+  fromLazyAvro (T.Union (S.Null :| [_])  _ T.Null) = pure Nothing
+  fromLazyAvro (T.Union (S.Null :| [_]) _ v)       = Just <$> fromLazyAvro v
+  fromLazyAvro v                                   = badLazyValue v "Maybe a"
+
+instance FromLazyAvro a => FromLazyAvro [a] where
+  fromLazyAvro (T.Array vec) = mapM fromLazyAvro $ toList vec
+  fromLazyAvro v             = badLazyValue v "[a]"
+
+instance FromLazyAvro a => FromLazyAvro (V.Vector a) where
+  fromLazyAvro (T.Array vec) = mapM fromLazyAvro vec
+  fromLazyAvro v             = badLazyValue v "Vector a"
+
+instance (U.Unbox a, FromLazyAvro a) => FromLazyAvro (U.Vector a) where
+  fromLazyAvro (T.Array vec) = U.convert <$> mapM fromLazyAvro vec
+  fromLazyAvro v             = badLazyValue v "Unboxed Vector a"
+
+instance FromLazyAvro Text where
+  fromLazyAvro (T.String txt) = pure txt
+  fromLazyAvro v              = badLazyValue v "Text"
+
+instance FromLazyAvro TL.Text where
+  fromLazyAvro (T.String txt) = pure (TL.fromStrict txt)
+  fromLazyAvro v              = badLazyValue v "Lazy Text"
+
+instance (FromLazyAvro a) => FromLazyAvro (Map.Map Text a) where
+  fromLazyAvro (T.Record _ mp) = mapM fromLazyAvro $ Map.fromList (HashMap.toList mp)
+  fromLazyAvro (T.Map mp)      = mapM fromLazyAvro $ Map.fromList (HashMap.toList mp)
+  fromLazyAvro v               = badLazyValue v "Map Text a"
+
+instance (FromLazyAvro a) => FromLazyAvro (HashMap.HashMap Text a) where
+  fromLazyAvro (T.Record _ mp) = mapM fromLazyAvro mp
+  fromLazyAvro (T.Map mp)      = mapM fromLazyAvro mp
+  fromLazyAvro v               = badLazyValue v "HashMap Text a"
+
+badLazyValue :: LazyValue Type -> String -> Result a
+badLazyValue v t = fail $ "Unexpected value when decoding for '" <> t <> "': " <> show v

--- a/src/Data/Avro/Deriving.hs
+++ b/src/Data/Avro/Deriving.hs
@@ -32,41 +32,44 @@ module Data.Avro.Deriving
 )
 where
 
-import           Control.Monad                 (join)
-import           Data.Aeson                    (eitherDecode)
-import qualified Data.Aeson                    as J
-import           Data.Avro                     hiding (decode, encode)
-import           Data.Avro.Schema              as S
-import qualified Data.Avro.Types               as AT
-import           Data.ByteString               (ByteString)
-import qualified Data.ByteString               as B
-import           Data.Char                     (isAlphaNum)
+import           Control.Monad                      (join)
+import           Data.Aeson                         (eitherDecode)
+import qualified Data.Aeson                         as J
+import           Data.Avro                          hiding (decode, encode)
+import           Data.Avro.Schema                   as S
+import qualified Data.Avro.Types                    as AT
+import           Data.ByteString                    (ByteString)
+import qualified Data.ByteString                    as B
+import           Data.Char                          (isAlphaNum)
 import           Data.Int
-import           Data.List.NonEmpty            (NonEmpty ((:|)))
-import qualified Data.List.NonEmpty            as NE
-import           Data.Map                      (Map)
-import           Data.Maybe                    (fromMaybe)
-import           Data.Semigroup                ((<>))
-import qualified Data.Text                     as Text
+import           Data.List.NonEmpty                 (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty                 as NE
+import           Data.Map                           (Map)
+import           Data.Maybe                         (fromMaybe)
+import           Data.Semigroup                     ((<>))
+import qualified Data.Text                          as Text
 
 
-import           GHC.Generics                  (Generic)
+import           GHC.Generics                       (Generic)
 
-import           Language.Haskell.TH           as TH hiding (notStrict)
-import           Language.Haskell.TH.Lib       as TH hiding (notStrict)
+import           Language.Haskell.TH                as TH hiding (notStrict)
+import           Language.Haskell.TH.Lib            as TH hiding (notStrict)
 import           Language.Haskell.TH.Syntax
 
 import           Data.Avro.Deriving.NormSchema
 import           Data.Avro.EitherN
 
-import qualified Data.ByteString               as BS
-import qualified Data.ByteString.Lazy          as LBS
-import qualified Data.ByteString.Lazy.Char8    as LBSC8
-import qualified Data.HashMap.Strict           as HM
-import qualified Data.Set                      as S
-import           Data.Text                     (Text)
-import qualified Data.Text                     as T
-import qualified Data.Vector                   as V
+import qualified Data.ByteString                    as BS
+import qualified Data.ByteString.Lazy               as LBS
+import qualified Data.ByteString.Lazy.Char8         as LBSC8
+import qualified Data.HashMap.Strict                as HM
+import qualified Data.Set                           as S
+import           Data.Text                          (Text)
+import qualified Data.Text                          as T
+import qualified Data.Vector                        as V
+
+import           Data.Avro.Decode.Lazy.FromLazyAvro
+import qualified Data.Avro.Decode.Lazy.LazyValue    as LV
 
 -- | How to treat Avro namespaces in the generated Haskell types.
 data NamespaceBehavior =
@@ -185,7 +188,7 @@ mkStrictPrimitiveField _ field =
 -- Person { firstName :: Text }
 -- @
 -- You may want to enable 'DuplicateRecordFields' if you want to use this method.
-mkAsIsFieldName :: TypeName -> Field -> Text
+mkAsIsFieldName :: Text -> Field -> Text
 mkAsIsFieldName _ = sanitiseName . updateFirst T.toLower . fldName
 
 -- | Derives Haskell types from the given Avro schema file. These
@@ -233,8 +236,9 @@ deriveAvroWithOptions' o s = do
   types     <- traverse (genType o) schemas
   hasSchema <- traverse (genHasAvroSchema $ namespaceBehavior o) schemas
   fromAvros <- traverse (genFromAvro $ namespaceBehavior o) schemas
+  fromLazyAvros <- traverse (genFromLazyAvro $ namespaceBehavior o) schemas
   toAvros   <- traverse (genToAvro o) schemas
-  pure $ join types <> join hasSchema <> join fromAvros <> join toAvros
+  pure $ join types <> join hasSchema <> join fromAvros <> join fromLazyAvros <> join toAvros
 
 -- | Derives "read only" Avro from a given schema file. For a schema
 -- with a top-level definition @com.example.Foo@, this generates:
@@ -265,7 +269,8 @@ deriveFromAvroWithOptions' o s = do
   types     <- traverse (genType o) schemas
   hasSchema <- traverse (genHasAvroSchema $ namespaceBehavior o) schemas
   fromAvros <- traverse (genFromAvro $ namespaceBehavior o) schemas
-  pure $ join types <> join hasSchema <> join fromAvros
+  fromLazyAvros <- traverse (genFromLazyAvro $ namespaceBehavior o) schemas
+  pure $ join types <> join hasSchema <> join fromAvros <> join fromLazyAvros
 
 -- | Same as 'deriveAvroWithOptions' but uses 'defaultDeriveOptions'
 --
@@ -338,6 +343,40 @@ genFromAvro namespaceBehavior (S.Fixed n _ s) =
   |]
 genFromAvro _ _                             = pure []
 
+--- EXPERIMENTAL :: LAZY
+genFromLazyAvro :: NamespaceBehavior -> Schema -> Q [Dec]
+genFromLazyAvro namespaceBehavior (S.Enum n _ _ _ _) =
+  [d| instance FromLazyAvro $(conT $ mkDataTypeName namespaceBehavior n) where
+        fromLazyAvro (LV.Enum _ i _) = $([| pure . toEnum|]) i
+        fromLazyAvro value           = $( [|\v -> badLazyValue v $(mkTextLit $ S.renderFullname n)|] ) value
+  |]
+genFromLazyAvro namespaceBehavior (S.Record n _ _ _ fs) =
+  [d| instance FromLazyAvro $(conT $ mkDataTypeName namespaceBehavior n) where
+        fromLazyAvro (LV.Record _ r) =
+           $(genFromLazyAvroFieldsExp (mkDataTypeName namespaceBehavior n) fs) r
+        fromLazyAvro value           = $( [|\v -> badLazyValue v $(mkTextLit $ S.renderFullname n)|] ) value
+  |]
+genFromLazyAvro namespaceBehavior (S.Fixed n _ s) =
+  [d| instance FromLazyAvro $(conT $ mkDataTypeName namespaceBehavior n) where
+        fromLazyAvro (LV.Fixed _ v)
+          | BS.length v == s = pure $ $(conE (mkDataTypeName namespaceBehavior n)) v
+        fromLazyAvro value = $( [|\v -> badLazyValue v $(mkTextLit $ S.renderFullname n)|] ) value
+  |]
+genFromLazyAvro _ _                             = pure []
+
+
+genFromLazyAvroFieldsExp :: Name -> [Field] -> Q Exp
+genFromLazyAvroFieldsExp n []     = [| (return . return) $(conE n) |]
+genFromLazyAvroFieldsExp n (x:xs) =
+  [| \r ->
+    $(let extract fld = [| r .~: T.pack $(mkTextLit (fldName fld))|]
+          ctor = [| $(conE n) <$> $(extract x) |]
+      in foldl (\expr fld -> [| $expr <*> $(extract fld) |]) ctor xs
+     )
+  |]
+
+-------------------------------------------------------------------------------
+
 genFromAvroFieldsExp :: Name -> [Field] -> Q Exp
 genFromAvroFieldsExp n []     = [| (return . return) $(conE n) |]
 genFromAvroFieldsExp n (x:xs) =
@@ -368,7 +407,7 @@ newNames :: String
 newNames base n = sequence [newName (base ++ show i) | i <- [1..n]]
 
 genToAvro :: DeriveOptions -> Schema -> Q [Dec]
-genToAvro opts s@(Enum n _ _ vs _) =
+genToAvro opts s@(S.Enum n _ _ vs _) =
   toAvroInstance (mkSchemaValueName (namespaceBehavior opts) n)
   where
     conP' = flip conP [] . mkAdtCtorName (namespaceBehavior opts) n
@@ -380,7 +419,7 @@ genToAvro opts s@(Enum n _ _ vs _) =
                                (normalB [| convert (T.pack $(mkTextLit v))|]) []) <$> vs))
               |])
       |]
-genToAvro opts s@(Record n _ _ _ fs) =
+genToAvro opts s@(S.Record n _ _ _ fs) =
   toAvroInstance (mkSchemaValueName (namespaceBehavior opts) n)
   where
     toAvroInstance sname =
@@ -397,7 +436,7 @@ genToAvro opts s@(Record n _ _ _ fs) =
                 )
             |]
 
-genToAvro opts s@(Fixed n _ size) =
+genToAvro opts s@(S.Fixed n _ size) =
   toAvroInstance (mkSchemaValueName (namespaceBehavior opts) n)
   where
     toAvroInstance sname =

--- a/src/Data/Avro/EitherN.hs
+++ b/src/Data/Avro/EitherN.hs
@@ -1,20 +1,117 @@
-{-# LANGUAGE DeriveGeneric  #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE DeriveFoldable      #-}
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Data.Avro.EitherN where
 
 import           Data.Avro
+import           Data.Avro.Decode.Lazy as AL
 import           Data.Avro.Schema
-import qualified Data.Avro.Types    as T
-import           Data.Tagged
+import qualified Data.Avro.Types       as T
+import           Data.Bifoldable       (Bifoldable (..))
+import           Data.Bifunctor        (Bifunctor (..))
+import           Data.Bitraversable    (Bitraversable (..))
 import           Data.List.NonEmpty
-import           GHC.Generics       (Generic)
+import           Data.Tagged
+import           GHC.Generics          (Generic)
 
-data Either3 a b c = E3_1 a | E3_2 b | E3_3 c deriving (Eq, Ord, Show, Generic)
+data Either3 a b c = E3_1 a | E3_2 b | E3_3 c deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
 
-data Either4 a b c d = E4_1 a | E4_2 b | E4_3 c | E4_4 d deriving (Eq, Ord, Show, Generic)
+data Either4 a b c d = E4_1 a | E4_2 b | E4_3 c | E4_4 d deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
 
-data Either5 a b c d e = E5_1 a | E5_2 b | E5_3 c | E5_4 d | E5_5 e deriving (Eq, Ord, Show, Generic)
+data Either5 a b c d e = E5_1 a | E5_2 b | E5_3 c | E5_4 d | E5_5 e deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
+
+instance Applicative (Either3 a b) where
+  pure = E3_3
+  E3_1 a <*> _ = E3_1 a
+  E3_2 a <*> _ = E3_2 a
+  E3_3 f <*> r = fmap f r
+
+instance Applicative (Either4 a b c) where
+  pure = E4_4
+  E4_1 a <*> _ = E4_1 a
+  E4_2 a <*> _ = E4_2 a
+  E4_3 a <*> _ = E4_3 a
+  E4_4 f <*> r = fmap f r
+
+instance Applicative (Either5 a b c d) where
+  pure = E5_5
+  E5_1 a <*> _ = E5_1 a
+  E5_2 a <*> _ = E5_2 a
+  E5_3 a <*> _ = E5_3 a
+  E5_4 a <*> _ = E5_4 a
+  E5_5 f <*> r = fmap f r
+
+instance Bifunctor (Either3 a) where
+  bimap _ _ (E3_1 a) = E3_1 a
+  bimap f _ (E3_2 a) = E3_2 (f a)
+  bimap _ g (E3_3 a) = E3_3 (g a)
+
+instance Bifunctor (Either4 a b) where
+  bimap _ _ (E4_1 a) = E4_1 a
+  bimap _ _ (E4_2 a) = E4_2 a
+  bimap f _ (E4_3 a) = E4_3 (f a)
+  bimap _ g (E4_4 a) = E4_4 (g a)
+
+instance Bifunctor (Either5 a b c) where
+  bimap _ _ (E5_1 a) = E5_1 a
+  bimap _ _ (E5_2 a) = E5_2 a
+  bimap _ _ (E5_3 a) = E5_3 a
+  bimap f _ (E5_4 a) = E5_4 (f a)
+  bimap _ g (E5_5 a) = E5_5 (g a)
+
+instance Monad (Either3 a b) where
+  E3_1 a >>= _ = E3_1 a
+  E3_2 a >>= _ = E3_2 a
+  E3_3 a >>= f = f a
+
+instance Monad (Either4 a b c) where
+  E4_1 a >>= _ = E4_1 a
+  E4_2 a >>= _ = E4_2 a
+  E4_3 a >>= _ = E4_3 a
+  E4_4 a >>= f = f a
+
+instance Monad (Either5 a b c d) where
+  E5_1 a >>= _ = E5_1 a
+  E5_2 a >>= _ = E5_2 a
+  E5_3 a >>= _ = E5_3 a
+  E5_4 a >>= _ = E5_4 a
+  E5_5 a >>= f = f a
+
+instance Bifoldable (Either3 a) where
+  bifoldMap f _ (E3_2 a) = f a
+  bifoldMap _ g (E3_3 a) = g a
+  bifoldMap _ _ _        = mempty
+
+instance Bifoldable (Either4 a b) where
+  bifoldMap f _ (E4_3 a) = f a
+  bifoldMap _ g (E4_4 a) = g a
+  bifoldMap _ _ _        = mempty
+
+instance Bifoldable (Either5 a b c) where
+  bifoldMap f _ (E5_4 a) = f a
+  bifoldMap _ g (E5_5 a) = g a
+  bifoldMap _ _ _        = mempty
+
+instance Bitraversable (Either3 a) where
+  bitraverse _ _ (E3_1 a) = pure (E3_1 a)
+  bitraverse f _ (E3_2 a) = E3_2 <$> f a
+  bitraverse _ g (E3_3 a) = E3_3 <$> g a
+
+instance Bitraversable (Either4 a b) where
+  bitraverse _ _ (E4_1 a) = pure (E4_1 a)
+  bitraverse _ _ (E4_2 a) = pure (E4_2 a)
+  bitraverse f _ (E4_3 a) = E4_3 <$> f a
+  bitraverse _ g (E4_4 a) = E4_4 <$> g a
+
+instance Bitraversable (Either5 a b c) where
+  bitraverse _ _ (E5_1 a) = pure (E5_1 a)
+  bitraverse _ _ (E5_2 a) = pure (E5_2 a)
+  bitraverse _ _ (E5_3 a) = pure (E5_3 a)
+  bitraverse f _ (E5_4 a) = E5_4 <$> f a
+  bitraverse _ g (E5_5 a) = E5_5 <$> g a
 
 instance (HasAvroSchema a, HasAvroSchema b, HasAvroSchema c) => HasAvroSchema (Either3 a b c) where
   schema = Tagged $ mkUnion (untag (schema :: Tagged a Type) :| [
@@ -42,11 +139,11 @@ instance (FromAvro a, FromAvro b, FromAvro c) => FromAvro (Either3 a b c) where
     | matches branch schemaA = E3_1 <$> fromAvro x
     | matches branch schemaB = E3_2 <$> fromAvro x
     | matches branch schemaC = E3_3 <$> fromAvro x
-    | otherwise              = badValue e "either3"
+    | otherwise              = badValue e "Either3"
     where Tagged schemaA = schema :: Tagged a Type
           Tagged schemaB = schema :: Tagged b Type
           Tagged schemaC = schema :: Tagged c Type
-  fromAvro x = badValue x "either3"
+  fromAvro x = badValue x "Either3"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d) => FromAvro (Either4 a b c d) where
   fromAvro e@(T.Union _ branch x)
@@ -54,12 +151,12 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d) => FromAvro (Either4 a
     | matches branch schemaB = E4_2 <$> fromAvro x
     | matches branch schemaC = E4_3 <$> fromAvro x
     | matches branch schemaD = E4_4 <$> fromAvro x
-    | otherwise              = badValue e "either4"
+    | otherwise              = badValue e "Either4"
     where Tagged schemaA = schema :: Tagged a Type
           Tagged schemaB = schema :: Tagged b Type
           Tagged schemaC = schema :: Tagged c Type
           Tagged schemaD = schema :: Tagged d Type
-  fromAvro x = badValue x "either4"
+  fromAvro x = badValue x "Either4"
 
 instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e) => FromAvro (Either5 a b c d e) where
   fromAvro e@(T.Union _ branch x)
@@ -68,13 +165,52 @@ instance (FromAvro a, FromAvro b, FromAvro c, FromAvro d, FromAvro e) => FromAvr
     | matches branch schemaC = E5_3 <$> fromAvro x
     | matches branch schemaD = E5_4 <$> fromAvro x
     | matches branch schemaE = E5_5 <$> fromAvro x
-    | otherwise              = badValue e "either5"
+    | otherwise              = badValue e "Either5"
     where Tagged schemaA = schema :: Tagged a Type
           Tagged schemaB = schema :: Tagged b Type
           Tagged schemaC = schema :: Tagged c Type
           Tagged schemaD = schema :: Tagged d Type
           Tagged schemaE = schema :: Tagged e Type
-  fromAvro x = badValue x "either5"
+  fromAvro x = badValue x "Either5"
+
+instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c) => FromLazyAvro (Either3 a b c) where
+  fromLazyAvro e@(AL.Union _ branch x)
+    | matches branch schemaA = E3_1 <$> fromLazyAvro x
+    | matches branch schemaB = E3_2 <$> fromLazyAvro x
+    | matches branch schemaC = E3_3 <$> fromLazyAvro x
+    | otherwise              = badValue e "Either3"
+    where Tagged schemaA = schema :: Tagged a Type
+          Tagged schemaB = schema :: Tagged b Type
+          Tagged schemaC = schema :: Tagged c Type
+  fromLazyAvro x = badValue x "Either3"
+
+instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c, FromLazyAvro d) => FromLazyAvro (Either4 a b c d) where
+  fromLazyAvro e@(AL.Union _ branch x)
+    | matches branch schemaA = E4_1 <$> fromLazyAvro x
+    | matches branch schemaB = E4_2 <$> fromLazyAvro x
+    | matches branch schemaC = E4_3 <$> fromLazyAvro x
+    | matches branch schemaD = E4_4 <$> fromLazyAvro x
+    | otherwise              = badValue e "Either4"
+    where Tagged schemaA = schema :: Tagged a Type
+          Tagged schemaB = schema :: Tagged b Type
+          Tagged schemaC = schema :: Tagged c Type
+          Tagged schemaD = schema :: Tagged d Type
+  fromLazyAvro x = badValue x "Either4"
+
+instance (FromLazyAvro a, FromLazyAvro b, FromLazyAvro c, FromLazyAvro d, FromLazyAvro e) => FromLazyAvro (Either5 a b c d e) where
+  fromLazyAvro e@(AL.Union _ branch x)
+    | matches branch schemaA = E5_1 <$> fromLazyAvro x
+    | matches branch schemaB = E5_2 <$> fromLazyAvro x
+    | matches branch schemaC = E5_3 <$> fromLazyAvro x
+    | matches branch schemaD = E5_4 <$> fromLazyAvro x
+    | matches branch schemaE = E5_5 <$> fromLazyAvro x
+    | otherwise              = badValue e "Either5"
+    where Tagged schemaA = schema :: Tagged a Type
+          Tagged schemaB = schema :: Tagged b Type
+          Tagged schemaC = schema :: Tagged c Type
+          Tagged schemaD = schema :: Tagged d Type
+          Tagged schemaE = schema :: Tagged e Type
+  fromLazyAvro x = badValue x "Either5"
 
 instance (ToAvro a, ToAvro b, ToAvro c) => ToAvro (Either3 a b c) where
   toAvro e =

--- a/src/Data/Avro/FromAvro.hs
+++ b/src/Data/Avro/FromAvro.hs
@@ -1,38 +1,36 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE MultiWayIf #-}
 module Data.Avro.FromAvro
 
 where
 
-import           Control.Arrow        (first)
+import           Control.Arrow           (first)
+import qualified Data.Avro.Encode        as E
 import           Data.Avro.HasAvroSchema
-import qualified Data.Avro.Encode     as E
-import           Data.Avro.Schema     as S
-import           Data.Avro.Types      as T
-import qualified Data.ByteString      as B
-import           Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as BL
-import           Data.Foldable        (toList)
-import qualified Data.HashMap.Strict  as HashMap
+import           Data.Avro.Schema        as S
+import           Data.Avro.Types         as T
+import qualified Data.ByteString         as B
+import           Data.ByteString.Lazy    (ByteString)
+import qualified Data.ByteString.Lazy    as BL
+import           Data.Foldable           (toList)
+import qualified Data.HashMap.Strict     as HashMap
 import           Data.Int
-import           Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.Map             as Map
-import           Data.Monoid          ((<>))
-import           Data.Text            (Text)
-import qualified Data.Text            as Text
-import qualified Data.Text.Lazy       as TL
+import           Data.List.NonEmpty      (NonEmpty (..))
+import qualified Data.Map                as Map
+import           Data.Monoid             ((<>))
 import           Data.Tagged
-import qualified Data.Vector          as V
-import qualified Data.Vector.Unboxed  as U
+import           Data.Text               (Text)
+import qualified Data.Text               as Text
+import qualified Data.Text.Lazy          as TL
+import qualified Data.Vector             as V
+import qualified Data.Vector.Unboxed     as U
 import           Data.Word
 
 class HasAvroSchema a => FromAvro a where
   fromAvro :: Value Type -> Result a
-
--- instance FromAvro (Value Type) where
---   fromAvro = pure
 
 (.:) :: FromAvro a => HashMap.HashMap Text (Value Type) -> Text -> Result a
 (.:) obj key =
@@ -44,32 +42,39 @@ instance (FromAvro a, FromAvro b) => FromAvro (Either a b) where
   fromAvro e@(T.Union _ branch x)
     | S.matches branch schemaA = Left  <$> fromAvro x
     | S.matches branch schemaB = Right <$> fromAvro x
-    | otherwise              = badValue e "either"
+    | otherwise              = badValue e "Either"
     where Tagged schemaA = schema :: Tagged a Type
           Tagged schemaB = schema :: Tagged b Type
-  fromAvro x = badValue x "either"
+  fromAvro x = badValue x "Either"
+
 instance FromAvro Bool where
   fromAvro (T.Boolean b) = pure b
   fromAvro v             = badValue v "Bool"
+
 instance FromAvro B.ByteString where
   fromAvro (T.Bytes b) = pure b
-  fromAvro v          = badValue v "ByteString"
+  fromAvro v           = badValue v "ByteString"
+
 instance FromAvro BL.ByteString where
   fromAvro (T.Bytes b) = pure (BL.fromStrict b)
-  fromAvro v          = badValue v "Lazy ByteString"
+  fromAvro v           = badValue v "Lazy ByteString"
+
 instance FromAvro Int where
   fromAvro (T.Int i) | (fromIntegral i :: Integer) < fromIntegral (maxBound :: Int)
                       = pure (fromIntegral i)
   fromAvro (T.Long i) | (fromIntegral i :: Integer) < fromIntegral (maxBound :: Int)
                       = pure (fromIntegral i)
   fromAvro v          = badValue v "Int"
+
 instance FromAvro Int32 where
-  fromAvro (T.Int i)  = pure (fromIntegral i)
-  fromAvro v          = badValue v "Int32"
+  fromAvro (T.Int i) = pure (fromIntegral i)
+  fromAvro v         = badValue v "Int32"
+
 instance FromAvro Int64 where
   fromAvro (T.Long i) = pure i
   fromAvro (T.Int i)  = pure (fromIntegral i)
-  fromAvro v = badValue v "Int64"
+  fromAvro v          = badValue v "Int64"
+
 instance FromAvro Double where
   fromAvro (T.Double d) = pure d
   fromAvro v            = badValue v "Double"
@@ -81,11 +86,11 @@ instance FromAvro Float where
 instance FromAvro a => FromAvro (Maybe a) where
   fromAvro (T.Union (S.Null :| [_])  _ T.Null) = pure Nothing
   fromAvro (T.Union (S.Null :| [_]) _ v)       = Just <$> fromAvro v
-  fromAvro v = badValue v "Maybe a"
+  fromAvro v                                   = badValue v "Maybe a"
 
 instance FromAvro a => FromAvro [a] where
   fromAvro (T.Array vec) = mapM fromAvro $ toList vec
-  fromAvro v = badValue v "[a]"
+  fromAvro v             = badValue v "[a]"
 
 instance FromAvro a => FromAvro (V.Vector a) where
   fromAvro (T.Array vec) = mapM fromAvro vec
@@ -97,21 +102,19 @@ instance (U.Unbox a, FromAvro a) => FromAvro (U.Vector a) where
 
 instance FromAvro Text where
   fromAvro (T.String txt) = pure txt
-  fromAvro v = badValue v "Text"
+  fromAvro v              = badValue v "Text"
 
 instance FromAvro TL.Text where
   fromAvro (T.String txt) = pure (TL.fromStrict txt)
-  fromAvro v = badValue v "Lazy Text"
+  fromAvro v              = badValue v "Lazy Text"
 
 instance (FromAvro a) => FromAvro (Map.Map Text a) where
   fromAvro (T.Record _ mp) = mapM fromAvro $ Map.fromList (HashMap.toList mp)
-  fromAvro (T.Map mp)  = mapM fromAvro $ Map.fromList (HashMap.toList mp)
-  fromAvro v = badValue v "Map Text a"
+  fromAvro (T.Map mp)      = mapM fromAvro $ Map.fromList (HashMap.toList mp)
+  fromAvro v               = badValue v "Map Text a"
 
 instance (FromAvro a) => FromAvro (HashMap.HashMap Text a) where
   fromAvro (T.Record _ mp) = mapM fromAvro mp
-  fromAvro (T.Map mp)    = mapM fromAvro mp
-  fromAvro v = badValue v "HashMap Text a"
+  fromAvro (T.Map mp)      = mapM fromAvro mp
+  fromAvro v               = badValue v "HashMap Text a"
 
-badValue :: Value Type -> String -> Result a
-badValue v t = fail $ "Unexpected value when decoding for '" <> t <> "': " <> show v

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -28,7 +28,9 @@ module Data.Avro.Schema
   , typeName
   , buildTypeEnvironment
   , extractBindings
+
   , Result(..)
+  , badValue
   , resultToEither
 
   , matches
@@ -492,6 +494,9 @@ instance ToJSON (Ty.Value Type) where
 
 data Result a = Success a | Error String
   deriving (Eq, Ord, Show)
+
+badValue :: Show t => t -> String -> Result a
+badValue v t = fail $ "Unexpected value for '" <> t <> "': " <> show v
 
 resultToEither :: Result b -> Either String b
 resultToEither r =

--- a/test/Avro/Decode/Lazy/ContainerSpec.hs
+++ b/test/Avro/Decode/Lazy/ContainerSpec.hs
@@ -47,7 +47,7 @@ spec = describe "Avro.Decode.Lazy.ContainerSpec" $ do
     res <- encodeThenDecode chunks
     sequence res `shouldBe` Right msgs
 
-encodeThenDecode :: (FromAvro a, ToAvro a) => [[a]] -> IO [Either String a]
+encodeThenDecode :: (FromLazyAvro a, ToAvro a) => [[a]] -> IO [Either String a]
 encodeThenDecode as =
   DL.decodeContainer <$> A.encodeContainer as
 


### PR DESCRIPTION
## Changes
An iteration on the experimental Lazy decoding:

- Add `FromLazyAvro` which is just like `FromAvro` except that it decodes directly from `LazyValue`  without converting to `Value`. In our cases with large and complicated messages, it delivers up to 25% of performance!

-  Generate `FromLazyAvro` instances when deriving data types from schemas.

- Add useful instances for  `EitherN` (`Functor`, `Bifunctor`, `Traversable`, `Bitraversable`,  `Foldable`, `Bifoldable`, `Applicative`, `Monad`)