### PR TITLE
Null namespace handling

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 # Revision history for avro
 
-## HEAD  -- 2018-11-07
+## To-be-released
+
+- Fixed bugs in handling of namespaces when parsing and printing avro types
+- Fixed a schema overlay test
+
+## 0.4.1.0
 
 * Fixed an omitted data fixture from the cabal sdist
 

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -214,9 +214,8 @@ instance Show TypeName where
 -- ".Foo"
 -- @
 renderFullname :: TypeName -> T.Text
-renderFullname TN { baseName, namespace } = case namespace of
-  [] -> "." <> baseName
-  xs -> T.intercalate "." $ namespace <> [baseName]
+renderFullname TN { baseName, namespace } =
+  T.intercalate "." namespace <> "." <> baseName
 
 -- | Parses a fullname into a 'TypeName', assuming the string
 -- representation is valid.
@@ -226,13 +225,10 @@ renderFullname TN { baseName, namespace } = case namespace of
 -- TN { baseName = "Foo", components = ["com", "example"] }
 -- @
 parseFullname :: T.Text -> TypeName
-parseFullname (T.splitOn "." -> components) = TN bn ns
+parseFullname (T.splitOn "." -> components) = TN { baseName, namespace }
   where
-    bn = last components
-    ns = case init components of
-      []   -> []
-      [""] -> []
-      xs   -> xs
+    baseName  = last components
+    namespace = filter (/= "") (init components)
 
 -- | Build a type name out of the @name@ and @namespace@ fields of an
 -- Avro record, enum or fixed definition.

--- a/test/data/overlay/composite.avsc
+++ b/test/data/overlay/composite.avsc
@@ -20,13 +20,17 @@
     },
     {
       "name": "foo-bar-array",
-      "type": "array",
-      "items": "avro.test.data.overlay.primitive.foo-bar"
+      "type": {
+        "type": "array",
+        "items": "avro.test.data.overlay.primitive.foo-bar"
+      }
     },
     {
       "name": "foo-bar-map",
-      "type": "map",
-      "values": "avro.test.data.overlay.primitive.foo-bar"
+      "type": {
+        "type": "map",
+        "values": "avro.test.data.overlay.primitive.foo-bar"
+      }
     },
     {
       "name": "foo-bar-int-union",


### PR DESCRIPTION
Fix a bug in the parsing and printing of type names in the null namespace.

There previously was ambiguity about whether the null namespace corresponds to `TN _ []` or `TN _ [""]`, which resulted in false negative equality checks when comparing type names in data against type names in a schema.

~~This is a WIP PR (please don't merge it!) because it causes an unexpected test failure for `overlay`~~

This is not a WIP PR. Please put it through the ringer and merge when ready! I did not solve the mystery of why my patch broke the schema overlay test. However I believe the test may have been using a buggy fixture - I *think* I fixed the schema format for the fixture in d166a87f6193c0073ed6452a997e17f14b72d22d