### PR TITLE
Fixed how we decode JSON unions with no namespaces.

### DIFF
--- a/avro.cabal
+++ b/avro.cabal
@@ -34,6 +34,8 @@ extra-source-files:
     test/data/namespace-inference.json
     test/data/unions-object-a.json
     test/data/unions-object-b.json
+    test/data/unions.avsc
+    test/data/unions-no-namespace.avsc
     test/data/deconflict/reader.avsc
     test/data/deconflict/writer.avsc
     test/data/overlay/composite.avsc

--- a/package.yaml
+++ b/package.yaml
@@ -21,7 +21,6 @@ dependencies:
 - binary
 - bytestring
 - containers
-- entropy
 - fail
 - hashable
 - mtl
@@ -30,6 +29,7 @@ dependencies:
 - semigroups
 - tagged
 - text
+- tf-random
 - unordered-containers
 - vector
 library:

--- a/src/Data/Avro/JSON.hs
+++ b/src/Data/Avro/JSON.hs
@@ -96,11 +96,14 @@ decodeAvroJSON schema json =
           fail "Invalid encoding of union: object with too many fields."
       | otherwise      =
           let
+            canonicalize name
+              | Just _ <- Schema.primitiveType name = name
+              | otherwise = Schema.renderFullname $ Schema.parseFullname name
             branch =
-              head (HashMap.keys obj)
+              head $ HashMap.keys obj
             names =
               HashMap.fromList [(Schema.typeName t, t) | t <- NE.toList schemas]
-          in case HashMap.lookup branch names of
+          in case HashMap.lookup (canonicalize branch) names of
             Just t  -> do
               nested <- parseAvroJSON union env t (obj ! branch)
               return (Avro.Union schemas t nested)

--- a/src/Data/Avro/Schema.hs
+++ b/src/Data/Avro/Schema.hs
@@ -22,10 +22,12 @@ module Data.Avro.Schema
   , Field(..), Order(..)
   , TypeName(..)
   , renderFullname
+  , parseFullname
   , mkEnum, mkUnion
   , validateSchema
   -- * Lower level utilities
   , typeName
+  , primitiveType
   , buildTypeEnvironment
   , extractBindings
 
@@ -294,6 +296,27 @@ typeName bt =
     NamedType name -> renderFullname name
     Union (x:|_) _ -> typeName x
     _              -> renderFullname $ name bt
+
+-- | If the given string is the name of a primitive type, return the
+-- type, otherwise return 'Nothing'.
+--
+-- @
+-- λ> primitiveType "string"
+-- Just String
+-- λ> primitiveType "foo"
+-- Nothing
+-- @
+primitiveType :: Text -> Maybe Type
+primitiveType = \case
+  "null"    -> Just Null
+  "boolean" -> Just Boolean
+  "int"     -> Just Int
+  "long"    -> Just Long
+  "float"   -> Just Float
+  "double"  -> Just Double
+  "bytes"   -> Just Bytes
+  "string"  -> Just String
+  _         -> Nothing
 
 data Field = Field { fldName    :: Text
                    , fldAliases :: [Text]

--- a/test/Avro/JSONSpec.hs
+++ b/test/Avro/JSONSpec.hs
@@ -24,6 +24,7 @@ deriveAvro "test/data/enums.avsc"
 deriveAvro "test/data/reused.avsc"
 deriveAvro "test/data/small.avsc"
 deriveAvro "test/data/unions.avsc"
+deriveAvro "test/data/unions-no-namespace.avsc"
 
 spec :: Spec
 spec = describe "Avro.JSONSpec: JSON serialization/parsing" $ do
@@ -95,6 +96,20 @@ spec = describe "Avro.JSONSpec: JSON serialization/parsing" $ do
   it "should parse (unions)" $ do
     parseJSON unionsJsonA `shouldBe` pure unionsExampleA
     parseJSON unionsJsonB `shouldBe` pure unionsExampleB
+
+  let unionsNoNamespaceA = UnionsNoNamespace (Left TypeA)
+      unionsNoNamespaceB = UnionsNoNamespace (Right TypeB)
+  it "should roundtrip (unions-no-namespace)" $ do
+    parseJSON (Aeson.encode (toJSON unionsNoNamespaceA)) `shouldBe`
+      pure unionsNoNamespaceA
+    parseJSON (Aeson.encode (toJSON unionsNoNamespaceB)) `shouldBe`
+      pure unionsNoNamespaceB
+  let noNamespace = "test/data/unions-no-namespace-object.json"
+      objectA = "{ \"unionField\" : { \"TypeA\" : {} } }"
+      objectB = "{ \"unionField\" : { \"TypeB\" : {} } }"
+  it "should parse (unions-no-namespace)" $ do
+    parseJSON objectA `shouldBe` pure unionsNoNamespaceA
+    parseJSON objectB `shouldBe` pure unionsNoNamespaceB
 
 getFileName :: FilePath -> IO FilePath
 getFileName p = do

--- a/test/data/unions-no-namespace.avsc
+++ b/test/data/unions-no-namespace.avsc
@@ -1,0 +1,24 @@
+{
+  "type" : "record",
+  "name" : "UnionsNoNamespace",
+  "doc" : "An example schema that has a union whose components are types with no namespace. This was causing problems with our JSON parsing code.",
+  "fields" : [
+    {
+      "name" : "unionField",
+      "type" : [
+        {
+          "type" : "record",
+          "name" : "TypeA",
+          "doc" : "TypeA is in the null namespace but has no leading dot in the schema.",
+          "fields" : []
+        },
+        {
+          "type" : "record",
+          "name" : ".TypeB",
+          "doc" : "Note the leading dot—semantically this is the same as having no namespace, but it caused parsing issues in the past.",
+          "fields" : []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The old logic would error out if the JSON encoding used a name like `Foo` while the schema used `.Foo` (or vice-versa). `Foo` and `.Foo` should be treated equivalently as "`Foo` with no namespace".

This PR adds an explicit canonicalization step in the JSON logic to take care of this problem. This step required a bit of extra bookkeeping to deal with primitive types like `string` so that we don't try using `.string`.

I also added a regression test to `JSONSpec.hs` to catch this problem in the future.